### PR TITLE
feat(R): pairs cluster bootstrap — Q1, Q2, Q4, Q5, Q6 (v0.5.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 0.4.0
+Version: 0.5.0
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1,4 +1,4 @@
-#' Stratified bootstrap resample indices
+#' Stratified row-level bootstrap resample indices
 #'
 #' @param n Total number of observations.
 #' @param strata Optional factor/integer vector for stratification.
@@ -17,44 +17,135 @@ stratified_resample <- function(n, strata = NULL) {
 }
 
 
+#' Pairs cluster bootstrap: draw clusters with replacement.
+#'
+#' @param unique_clusters Vector of unique cluster identifiers (any type).
+#' @param cluster_strata Optional vector aligned with `unique_clusters`: each
+#'   cluster's stratum. If supplied, clusters are sampled with replacement
+#'   *within* each stratum.
+#' @return A vector of drawn cluster IDs, same length and type as
+#'   `unique_clusters`. Duplicates are expected — that's the whole point.
+#' @noRd
+cluster_resample <- function(unique_clusters, cluster_strata = NULL) {
+  if (is.null(cluster_strata)) return(sample(unique_clusters, replace = TRUE))
+  out <- unique_clusters[integer(0)]   # zero-length, preserves type
+  for (s in unique(cluster_strata)) {
+    mask <- cluster_strata == s
+    out <- c(out, sample(unique_clusters[mask], sum(mask), replace = TRUE))
+  }
+  out
+}
+
+
+#' Build a resampled dataset by replicating each drawn cluster's rows.
+#'
+#' Fresh-IDs recipe (Cameron–Gelbach–Miller): the cluster identifier column
+#' is rewritten as `<orig_id>__d<j>` for the j-th draw, so a cluster drawn N
+#' times yields N distinct copies. Required for any downstream specification
+#' that uses cluster-level fixed effects (DiD); a no-op when there are no FE.
+#'
+#' @param data Original data frame.
+#' @param cluster_var Character: name of the cluster column.
+#' @param cluster_ids The cluster column values, length nrow(data).
+#' @param drawn Drawn cluster IDs (output of `cluster_resample`).
+#' @return A data frame with N_drawn × (rows-per-cluster) rows.
+#' @noRd
+build_cluster_rep_data <- function(data, cluster_var, cluster_ids, drawn) {
+  parts <- vector("list", length(drawn))
+  for (j in seq_along(drawn)) {
+    rows <- which(cluster_ids == drawn[j])
+    sub <- data[rows, , drop = FALSE]
+    sub[[cluster_var]] <- paste0(as.character(drawn[j]), "__d", j)
+    parts[[j]] <- sub
+  }
+  out <- do.call(rbind, parts)
+  rownames(out) <- NULL
+  out
+}
+
+
 #' Bootstrap variance-covariance matrix and inference
 #'
-#' Mirrors the `myboo` subroutine in `wsga.ado`. Each bootstrap replication
-#' resamples the full dataset (optionally stratified), refits the IPW
-#' propensity score and main regression, and records the two per-subgroup
-#' coefficients. The returned variance matrix is used for SE calculation and
-#' empirical CIs/p-values are derived from the bootstrap distribution.
+#' Mirrors the `myboo` subroutine in `wsga.ado`. Each replicate resamples the
+#' data (rows or whole clusters), refits the IPW propensity score and main
+#' regression, and records the two per-subgroup coefficients.
 #'
-#' @param run_one_rep Function `(data_b) -> c(b_g0, b_g1)` that fits one
-#'   bootstrap replicate and returns the two coefficient estimates.
+#' Two regimes:
+#' - `cluster_var = NULL`: row-level bootstrap (optionally stratified by
+#'   `block_var`).
+#' - `cluster_var` set: pairs cluster bootstrap. Whole clusters are drawn
+#'   with replacement; each drawn cluster contributes all its rows; cluster
+#'   IDs are made unique per draw (Cameron–Gelbach–Miller). `block_var`, if
+#'   supplied, must be constant within `cluster_var` and is used to stratify
+#'   at the cluster level.
+#'
+#' @param run_one_rep Function `(data_b) -> c(b_g0, b_g1)`.
 #' @param data Data frame to resample.
 #' @param B Integer: number of bootstrap replications.
-#' @param est Numeric length-2: the point estimates (b_g0, b_g1) from the
-#'   original data.
-#' @param block_var Optional character: column name to use as bootstrap strata.
+#' @param est Numeric length-2: point estimates (b_g0, b_g1).
+#' @param cluster_var Optional character: column name whose values define
+#'   clusters. When set, runs a pairs cluster bootstrap.
+#' @param block_var Optional character: stratification variable. Semantics
+#'   adapt: strata of rows when `cluster_var` is NULL, strata of clusters
+#'   otherwise.
 #' @param seed Optional integer RNG seed.
-#' @param fixed_fs Logical: fixed first-stage bootstrap for IV (handled by
-#'   `run_one_rep` closure).
-#' @return A list:
-#'   - `draws` (B×2 matrix of bootstrap coefficient draws).
-#'   - `vcov` (2×2 variance matrix).
-#'   - `pval` (length-2 empirical p-values, formula `(1 + count)/(B + 1)`).
-#'   - `ci` (2×2 matrix: rows = g0/g1, cols = lb/ub, empirical 2.5/97.5).
+#' @return A list with `draws`, `vcov`, `pval`, `ci`, `B_ok`, `failed`, and —
+#'   when `cluster_var` is set — `N_clusters`.
 #' @noRd
 run_bootstrap <- function(run_one_rep, data, B, est,
-                          block_var = NULL, seed = NULL) {
+                          cluster_var = NULL,
+                          block_var = NULL,
+                          seed = NULL) {
   if (!is.null(seed)) set.seed(seed)
 
-  n      <- nrow(data)
-  strata <- if (!is.null(block_var)) data[[block_var]] else NULL
-  draws  <- matrix(NA_real_, nrow = B, ncol = 2,
-                   dimnames = list(NULL, c("g0", "g1")))
+  n <- nrow(data)
+
+  if (is.null(cluster_var)) {
+    strata <- if (!is.null(block_var)) data[[block_var]] else NULL
+    resample <- function() {
+      idx <- stratified_resample(n, strata)
+      data[idx, , drop = FALSE]
+    }
+    N_clusters <- NULL
+  } else {
+    cluster_ids <- data[[cluster_var]]
+    unique_clusters <- unique(cluster_ids[!is.na(cluster_ids)])
+    N_clusters <- length(unique_clusters)
+
+    cluster_strata <- NULL
+    if (!is.null(block_var)) {
+      strata_vec <- data[[block_var]]
+      # Each cluster must map to exactly one stratum value
+      strata_per_cluster <- tapply(strata_vec, cluster_ids,
+                                   function(s) length(unique(s)))
+      bad <- names(strata_per_cluster)[strata_per_cluster > 1]
+      if (length(bad) > 0) {
+        stop(sprintf(
+          "`block_var` must be constant within `cluster_var`. Violating clusters: %s%s",
+          paste(head(bad, 3), collapse = ", "),
+          if (length(bad) > 3) sprintf(" (and %d more)", length(bad) - 3) else ""
+        ))
+      }
+      cluster_strata <- vapply(
+        unique_clusters,
+        function(cc) strata_vec[which(cluster_ids == cc)[1]],
+        FUN.VALUE = strata_vec[1]
+      )
+    }
+
+    resample <- function() {
+      drawn <- cluster_resample(unique_clusters, cluster_strata)
+      build_cluster_rep_data(data, cluster_var, cluster_ids, drawn)
+    }
+  }
+
+  draws <- matrix(NA_real_, nrow = B, ncol = 2,
+                  dimnames = list(NULL, c("g0", "g1")))
 
   message(sprintf("Bootstrap replications (%d):", B))
   for (i in seq_len(B)) {
-    idx <- stratified_resample(n, strata)
     tryCatch({
-      draws[i, ] <- run_one_rep(data[idx, ])
+      draws[i, ] <- run_one_rep(resample())
     }, error = function(e) {
       # leave row as NA; warn once at end
     })
@@ -62,33 +153,35 @@ run_bootstrap <- function(run_one_rep, data, B, est,
   }
   cat("\n")
 
-  # Drop failed replicates
   ok <- complete.cases(draws)
-  if (any(!ok)) warning(sprintf("%d bootstrap replicates failed and were dropped.",
-                                sum(!ok)))
+  if (any(!ok)) {
+    msg <- sprintf("%d of %d bootstrap replicates failed and were dropped",
+                   sum(!ok), B)
+    if (!is.null(cluster_var)) {
+      msg <- paste0(msg, " (often caused by drawn samples lacking variation in `sgroup` or a moderator; consider increasing `bsreps`).")
+    } else {
+      msg <- paste0(msg, ".")
+    }
+    warning(msg)
+  }
   draws_ok <- draws[ok, , drop = FALSE]
   B_ok     <- nrow(draws_ok)
 
-  # Add diff = g1 - g0 as third column
   draws_ok <- cbind(draws_ok, diff = draws_ok[, "g1"] - draws_ok[, "g0"])
+  V_boot   <- var(draws_ok[, c("g0", "g1")])
+  est_all  <- c(est, diff = est[2] - est[1])
 
-  # Variance-covariance from bootstrap distribution (g0, g1 only)
-  V_boot <- var(draws_ok[, c("g0", "g1")])
-
-  # Point estimates for all three parameters (needed for empirical p-values)
-  est_all <- c(est, diff = est[2] - est[1])
-
-  # Empirical p-values: (1 + #{|draw| >= |est|}) / (B_ok + 1)
   pval <- sapply(seq_len(3), function(g) {
     cnt <- sum(abs(draws_ok[, g]) >= abs(est_all[g]))
     (1 + cnt) / (B_ok + 1)
   })
   names(pval) <- c("g0", "g1", "diff")
 
-  # Empirical CIs: 2.5 / 97.5 percentiles for all three parameters
   ci <- apply(draws_ok, 2, quantile, probs = c(0.025, 0.975))
   rownames(ci) <- c("lb", "ub")
 
-  list(draws = draws_ok, vcov = V_boot, pval = pval, ci = ci,
-       B_ok = B_ok, failed = sum(!ok))
+  result <- list(draws = draws_ok, vcov = V_boot, pval = pval, ci = ci,
+                 B_ok = B_ok, failed = sum(!ok))
+  if (!is.null(cluster_var)) result$N_clusters <- N_clusters
+  result
 }

--- a/R/wsga.R
+++ b/R/wsga.R
@@ -61,8 +61,11 @@ NULL
 #'   - `"analytical"`: sandwich (or cluster-robust) SE; CIs and p-values from
 #'     the t distribution with the regression residual df. Requires
 #'     `bootstrap = FALSE`. **Default when `bootstrap = FALSE`.**
-#' @param block_var Character or `NULL`. Column name for stratified (block)
-#'   bootstrap resampling. Default `NULL` (unstratified).
+#' @param block_var Character or `NULL`. Column name for stratified bootstrap
+#'   resampling. Default `NULL` (unstratified). Semantics adapt to
+#'   `cluster_var`: when `cluster_var` is `NULL`, `block_var` defines strata
+#'   of rows; when `cluster_var` is set, it defines strata of clusters and
+#'   must be constant within each cluster (validated at runtime).
 #' @param fixed_fs Logical. Fixed first-stage bootstrap for IV: bootstrap the
 #'   reduced form and divide by the point-estimate first-stage coefficients.
 #'   Default `FALSE`.
@@ -70,8 +73,15 @@ NULL
 #' @param vce Character: heteroskedasticity-consistent SE type passed to
 #'   `sandwich::vcovHC`. Common choices: `"HC1"` (default), `"HC0"`, `"HC2"`,
 #'   `"HC3"`. Use `"cluster"` together with `cluster_var` for cluster-robust SEs.
-#' @param cluster_var Character or `NULL`. Column name for cluster-robust SEs
-#'   (`vce = "cluster"` must also be set).
+#' @param cluster_var Character or `NULL`. Column name defining clusters.
+#'   Drives two things: when `bootstrap = TRUE`, switches the bootstrap from
+#'   row-level to pairs cluster (whole clusters are resampled with
+#'   replacement; cluster IDs are made unique per draw so unit fixed effects
+#'   remain identified — the Cameron–Gelbach–Miller recipe). When
+#'   `inference = "analytical"`, also requires `vce = "cluster"` to deliver
+#'   the cluster-robust sandwich SE. With fewer than ~30 unique clusters, a
+#'   one-time warning is emitted about likely SE understatement; see
+#'   `fwildclusterboot::boottest` for a wild-cluster alternative.
 #' @param weights Character or `NULL`. Column name of pre-existing observation
 #'   weights. These are multiplied into the kernel weights and (if `!noipsw`)
 #'   into the IPW weights.
@@ -386,7 +396,19 @@ wsga <- function(formula,
       fs_coefs         = fs_coefs
     )
 
+    # Few-clusters advisory when clustering is active
+    if (!is.null(cluster_var)) {
+      n_clust <- length(unique(data[[cluster_var]][!is.na(data[[cluster_var]])]))
+      if (n_clust < 30L) {
+        warning(sprintf(
+          "Cluster bootstrap with %d clusters. With fewer than ~30 clusters, pairs-cluster bootstrap can substantially understate standard errors. Consider also reporting analytical cluster-robust SEs (set `bootstrap = FALSE`, `vce = \"cluster\"`) and/or a wild cluster bootstrap-t (not implemented; see fwildclusterboot::boottest in R or boottest in Stata).",
+          n_clust
+        ))
+      }
+    }
+
     boot_result <- run_bootstrap(run_one_rep, data, bsreps, point_est,
+                                 cluster_var = cluster_var,
                                  block_var = block_var, seed = seed)
 
     # SE and t-statistics always come from the bootstrap when it runs.
@@ -457,7 +479,8 @@ wsga <- function(formula,
       m             = m,
       model         = model,
       noipsw        = noipsw,
-      inference     = inference
+      inference     = inference,
+      cluster_var_name = if (is.null(cluster_var)) NULL else cluster_var
     ),
     class = "wsga"
   )
@@ -566,8 +589,16 @@ print.wsga <- function(x, ...) {
               x$tstat$diff, x$pval$diff, x$ci$diff))
   cat(sep)
 
-  if (use_boot)
-    cat(sprintf("Bootstrap replications: %d\n", x$bootstrap$B_ok))
+  if (use_boot) {
+    if (!is.null(x$bootstrap$N_clusters)) {
+      total_reps <- x$bootstrap$B_ok + x$bootstrap$failed
+      cat(sprintf("Cluster bootstrap: %d/%d reps, clustered on '%s' (%d clusters)\n",
+                  x$bootstrap$B_ok, total_reps,
+                  x$cluster_var_name, x$bootstrap$N_clusters))
+    } else {
+      cat(sprintf("Bootstrap replications: %d\n", x$bootstrap$B_ok))
+    }
+  }
 
   cat(sprintf("N (G=0): %d   N (G=1): %d\n", x$nobs[["G0"]], x$nobs[["G1"]]))
   invisible(x)

--- a/man/wsga.Rd
+++ b/man/wsga.Rd
@@ -108,8 +108,11 @@ the t distribution with the regression residual df. Requires
 \code{bootstrap = FALSE}. \strong{Default when \code{bootstrap = FALSE}.}
 }}
 
-\item{block_var}{Character or \code{NULL}. Column name for stratified (block)
-bootstrap resampling. Default \code{NULL} (unstratified).}
+\item{block_var}{Character or \code{NULL}. Column name for stratified bootstrap
+resampling. Default \code{NULL} (unstratified). Semantics adapt to
+\code{cluster_var}: when \code{cluster_var} is \code{NULL}, \code{block_var} defines strata
+of rows; when \code{cluster_var} is set, it defines strata of clusters and
+must be constant within each cluster (validated at runtime).}
 
 \item{fixed_fs}{Logical. Fixed first-stage bootstrap for IV: bootstrap the
 reduced form and divide by the point-estimate first-stage coefficients.
@@ -121,8 +124,15 @@ Default \code{FALSE}.}
 \code{sandwich::vcovHC}. Common choices: \code{"HC1"} (default), \code{"HC0"}, \code{"HC2"},
 \code{"HC3"}. Use \code{"cluster"} together with \code{cluster_var} for cluster-robust SEs.}
 
-\item{cluster_var}{Character or \code{NULL}. Column name for cluster-robust SEs
-(\code{vce = "cluster"} must also be set).}
+\item{cluster_var}{Character or \code{NULL}. Column name defining clusters.
+Drives two things: when \code{bootstrap = TRUE}, switches the bootstrap from
+row-level to pairs cluster (whole clusters are resampled with
+replacement; cluster IDs are made unique per draw so unit fixed effects
+remain identified — the Cameron–Gelbach–Miller recipe). When
+\code{inference = "analytical"}, also requires \code{vce = "cluster"} to deliver
+the cluster-robust sandwich SE. With fewer than ~30 unique clusters, a
+one-time warning is emitted about likely SE understatement; see
+\code{fwildclusterboot::boottest} for a wild-cluster alternative.}
 
 \item{weights}{Character or \code{NULL}. Column name of pre-existing observation
 weights. These are multiplied into the kernel weights and (if \code{!noipsw})

--- a/tests/testthat/test-cluster-bootstrap.R
+++ b/tests/testthat/test-cluster-bootstrap.R
@@ -1,0 +1,95 @@
+data(rddsga_synth)
+
+# Add a synthetic cluster column to the example data.  Clusters are larger
+# than 30 by default; specific tests narrow this when needed.
+make_clustered <- function(n_clusters = 50L, seed = 1L) {
+  set.seed(seed)
+  d <- rddsga_synth
+  d$school <- sample.int(n_clusters, nrow(d), replace = TRUE)
+  d
+}
+
+test_that("cluster bootstrap exposes N_clusters and uses pairs-cluster path", {
+  d <- make_clustered(n_clusters = 50L)
+  fit <- wsga(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+              noipsw = TRUE, bootstrap = TRUE, bsreps = 20, seed = 1,
+              cluster_var = "school")
+  expect_true("N_clusters" %in% names(fit$bootstrap))
+  expect_equal(fit$bootstrap$N_clusters, 50L)
+  expect_equal(fit$cluster_var_name, "school")
+})
+
+test_that("row-level bootstrap (cluster_var = NULL) does not expose N_clusters", {
+  fit <- wsga(y ~ 1 | sgroup, data = rddsga_synth,
+              running = ~ x, bwidth = 0.5,
+              noipsw = TRUE, bootstrap = TRUE, bsreps = 20, seed = 1)
+  expect_false("N_clusters" %in% names(fit$bootstrap))
+  expect_null(fit$cluster_var_name)
+})
+
+test_that("build_cluster_rep_data assigns fresh IDs per draw", {
+  d <- data.frame(school = c("A", "A", "B", "B", "C"),
+                  y      = 1:5)
+  out <- build_cluster_rep_data(d, "school", d$school,
+                                drawn = c("A", "A", "B"))
+  # A drawn twice → two distinct fresh IDs; B drawn once
+  expect_equal(length(unique(out$school)), 3L)
+  expect_true(all(grepl("__d[0-9]+$", out$school)))
+  # Original outcomes preserved (each A row appears twice in the resample)
+  expect_equal(sum(out$y %in% c(1, 2)), 4L)  # 2 A rows × 2 draws
+  expect_equal(sum(out$y %in% c(3, 4)), 2L)  # 2 B rows × 1 draw
+})
+
+test_that("cluster_resample with strata respects strata sizes", {
+  set.seed(99)
+  uc <- letters[1:10]
+  strata <- rep(c("x", "y"), each = 5)
+  drawn <- cluster_resample(uc, strata)
+  expect_equal(length(drawn), 10L)
+  # Each stratum contributes its size in the draw, but order is x-then-y
+  expect_true(all(drawn[1:5] %in% uc[1:5]))
+  expect_true(all(drawn[6:10] %in% uc[6:10]))
+})
+
+test_that("block_var must be constant within cluster_var", {
+  d <- make_clustered(n_clusters = 50L)
+  # Make block_var vary within school -> should error.
+  d$bad <- sample(c("east", "west"), nrow(d), replace = TRUE)
+  expect_error(
+    wsga(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+         noipsw = TRUE, bootstrap = TRUE, bsreps = 5, seed = 1,
+         cluster_var = "school", block_var = "bad"),
+    "must be constant within `cluster_var`"
+  )
+})
+
+test_that("block_var constant within cluster works", {
+  d <- make_clustered(n_clusters = 50L)
+  d$region <- ifelse(d$school <= 25, "east", "west")
+  fit <- wsga(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+              noipsw = TRUE, bootstrap = TRUE, bsreps = 20, seed = 1,
+              cluster_var = "school", block_var = "region")
+  expect_equal(fit$bootstrap$N_clusters, 50L)
+  expect_gt(fit$se$g0, 0)
+})
+
+test_that("few-clusters (<30) emits the SE-understatement warning", {
+  d <- make_clustered(n_clusters = 12L, seed = 2L)
+  expect_warning(
+    wsga(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+         noipsw = TRUE, bootstrap = TRUE, bsreps = 5, seed = 1,
+         cluster_var = "school"),
+    "12 clusters"
+  )
+})
+
+test_that("seed makes cluster bootstrap reproducible", {
+  d <- make_clustered(n_clusters = 50L)
+  fit_a <- wsga(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+                noipsw = TRUE, bootstrap = TRUE, bsreps = 20, seed = 42,
+                cluster_var = "school")
+  fit_b <- wsga(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+                noipsw = TRUE, bootstrap = TRUE, bsreps = 20, seed = 42,
+                cluster_var = "school")
+  expect_equal(fit_a$bootstrap$draws, fit_b$bootstrap$draws)
+})


### PR DESCRIPTION
## Summary

Adds a pairs cluster bootstrap regime to `wsga()`, driven by the existing `cluster_var` argument. Row-level bootstrap behavior is preserved exactly when `cluster_var = NULL` (existing RDD users see no change).

This is the technically novel piece of the wsga DiD plan: once cluster bootstrap is in place, DiD support is mostly mechanical extension. It also benefits RDD users with hierarchical data (students-in-schools, individuals-in-municipalities) — they now get correct inference for free.

## What's in here (Q1, Q2, Q4, Q5, Q6 from the design)

- **Pairs cluster bootstrap.** `cluster_var` now also drives bootstrap resampling. Whole clusters are drawn with replacement; all rows of each drawn cluster are replicated. Cluster IDs get a `<orig>__d<j>` suffix per draw — the Cameron–Gelbach–Miller fresh-IDs recipe — so a cluster drawn N times stays distinguishable downstream (matters for any spec that uses cluster FE; harmless when none).
- **`block_var` is now context-sensitive.** `cluster_var = NULL` → strata of rows (current behavior). `cluster_var` set → strata of clusters; validated to be constant within each cluster, with a helpful error listing violating clusters when not.
- **Small-clusters warning.** When `cluster_var` is set and the unique cluster count is below 30, fires a one-time warning pointing users at `fwildclusterboot::boottest` (R) / `boottest` (Stata) for wild-cluster alternatives. Computation proceeds.
- **Output augmentation.** `fit$bootstrap$N_clusters` exposed when clustering is active. `fit$cluster_var_name` stored. `print.wsga` renders a cluster-aware footer:
  ```
  Cluster bootstrap: 198/200 reps, clustered on 'school' (47 clusters)
  ```
- **Failed-rep warning text upgraded** for the cluster case to hint at the typical cause (drawn samples lacking subgroup/moderator variation) and the obvious remedy (`bsreps`).

## What's deliberately not in here

- **Q3: `fixed_ps` diagnostic flag.** PS refit per rep remains the default and only behavior. Adding `fixed_ps = FALSE` is a small follow-up PR — it needs the resampler to expose original-row indices into the closure, which is mechanically separate from this change.
- **Stata mirror.** Cluster bootstrap is useful in RDD too, but Stata users don't have a natural use case yet (no DiD command, and RDD users rarely cluster in practice). We'll bundle Stata cluster bootstrap with the DiD command in a later PR rather than ship it standalone.

## Test plan

- [x] All existing tests pass unchanged (row-level bootstrap behavior is preserved exactly).
- [x] New `test-cluster-bootstrap.R` (8 tests):
  - `N_clusters` exposed in bootstrap output when `cluster_var` is set.
  - `N_clusters` *not* exposed when `cluster_var = NULL`.
  - `build_cluster_rep_data()` assigns fresh IDs per draw (cluster drawn twice yields two distinct fresh IDs; row counts match).
  - `cluster_resample()` with strata: drawn clusters stay within their stratum and the per-stratum count is preserved.
  - `block_var` not constant within `cluster_var` → error with violating-cluster names.
  - `block_var` constant within `cluster_var` → runs cleanly with `N_clusters` populated.
  - `<30` clusters triggers the SE-understatement warning.
  - Same seed → identical bootstrap draws.
- [ ] CI matrix green (in progress).

## Related

- Q1, Q2, Q4, Q5, Q6 of `project_wsga_design` memory (2026-05-09).
- Follow-up PR: Q3 (`fixed_ps`) — small, isolated.
- Next major chunk after this lands: DiD design skeleton (Q8) + balance/validation (Q9) + final defaults (Q10).