### PR TITLE
feat(R): fixed_ps diagnostic flag — Q3 (v0.6.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 0.5.0
+Version: 0.6.0
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -48,19 +48,26 @@ cluster_resample <- function(unique_clusters, cluster_strata = NULL) {
 #' @param cluster_var Character: name of the cluster column.
 #' @param cluster_ids The cluster column values, length nrow(data).
 #' @param drawn Drawn cluster IDs (output of `cluster_resample`).
-#' @return A data frame with N_drawn × (rows-per-cluster) rows.
+#' @return A list with two elements:
+#'   - `data`: data frame with `length(drawn) × rows-per-cluster` rows.
+#'   - `orig_idx`: integer vector of the same length, where
+#'     `orig_idx[k]` is the row in the original `data` that the k-th
+#'     row of the resampled data came from. Used by the `fixed_ps`
+#'     code path to look up the original-sample propensity score.
 #' @noRd
 build_cluster_rep_data <- function(data, cluster_var, cluster_ids, drawn) {
-  parts <- vector("list", length(drawn))
+  parts          <- vector("list", length(drawn))
+  orig_idx_parts <- vector("list", length(drawn))
   for (j in seq_along(drawn)) {
     rows <- which(cluster_ids == drawn[j])
     sub <- data[rows, , drop = FALSE]
     sub[[cluster_var]] <- paste0(as.character(drawn[j]), "__d", j)
-    parts[[j]] <- sub
+    parts[[j]]          <- sub
+    orig_idx_parts[[j]] <- rows
   }
   out <- do.call(rbind, parts)
   rownames(out) <- NULL
-  out
+  list(data = out, orig_idx = unlist(orig_idx_parts))
 }
 
 
@@ -104,7 +111,7 @@ run_bootstrap <- function(run_one_rep, data, B, est,
     strata <- if (!is.null(block_var)) data[[block_var]] else NULL
     resample <- function() {
       idx <- stratified_resample(n, strata)
-      data[idx, , drop = FALSE]
+      list(data = data[idx, , drop = FALSE], orig_idx = idx)
     }
     N_clusters <- NULL
   } else {
@@ -137,6 +144,7 @@ run_bootstrap <- function(run_one_rep, data, B, est,
       drawn <- cluster_resample(unique_clusters, cluster_strata)
       build_cluster_rep_data(data, cluster_var, cluster_ids, drawn)
     }
+    # build_cluster_rep_data already returns list(data = ..., orig_idx = ...)
   }
 
   draws <- matrix(NA_real_, nrow = B, ncol = 2,
@@ -144,8 +152,9 @@ run_bootstrap <- function(run_one_rep, data, B, est,
 
   message(sprintf("Bootstrap replications (%d):", B))
   for (i in seq_len(B)) {
+    r <- resample()
     tryCatch({
-      draws[i, ] <- run_one_rep(resample())
+      draws[i, ] <- run_one_rep(r$data, r$orig_idx)
     }, error = function(e) {
       # leave row as NA; warn once at end
     })

--- a/R/wsga.R
+++ b/R/wsga.R
@@ -69,6 +69,16 @@ NULL
 #' @param fixed_fs Logical. Fixed first-stage bootstrap for IV: bootstrap the
 #'   reduced form and divide by the point-estimate first-stage coefficients.
 #'   Default `FALSE`.
+#' @param fixed_ps Logical. Diagnostic flag. When `TRUE`, the propensity score
+#'   model is **not** refit inside the bootstrap loop; instead, each
+#'   resampled row inherits the propensity score (and common-support
+#'   membership) from its original-sample row. This isolates the
+#'   variance contribution of the outcome model from that of the
+#'   weight-estimation step. **It understates the SE relative to the
+#'   paper's intended interpretation**, which is why the default is
+#'   `FALSE`. Useful for sanity-checking and for fast iteration on the
+#'   outcome specification when the PS fit is expensive. No effect when
+#'   `noipsw = TRUE` or when there are no balance variables.
 #' @param seed Integer or `NULL`. RNG seed for reproducibility. Default `NULL`.
 #' @param vce Character: heteroskedasticity-consistent SE type passed to
 #'   `sandwich::vcovHC`. Common choices: `"HC1"` (default), `"HC0"`, `"HC2"`,
@@ -150,6 +160,7 @@ wsga <- function(formula,
                    inference   = NULL,
                    block_var   = NULL,
                    fixed_fs    = FALSE,
+                   fixed_ps    = FALSE,
                    seed        = NULL,
                    vce         = "HC1",
                    cluster_var = NULL,
@@ -393,7 +404,10 @@ wsga <- function(formula,
       vce              = vce,
       cluster_var_name = cluster_var,
       fixed_fs         = fixed_fs,
-      fs_coefs         = fs_coefs
+      fs_coefs         = fs_coefs,
+      fixed_ps            = fixed_ps,
+      original_pscore     = pscore,
+      original_comsup_idx = comsup_idx
     )
 
     # Few-clusters advisory when clustering is active
@@ -480,7 +494,8 @@ wsga <- function(formula,
       model         = model,
       noipsw        = noipsw,
       inference     = inference,
-      cluster_var_name = if (is.null(cluster_var)) NULL else cluster_var
+      cluster_var_name = if (is.null(cluster_var)) NULL else cluster_var,
+      fixed_ps      = fixed_ps
     ),
     class = "wsga"
   )
@@ -493,8 +508,11 @@ make_boot_rep <- function(outcome_name, running_name, cutoff, bwidth,
                           obs_wt_name, obs_weights_vec,
                           kernel, noipsw, ps_model, comsup, m,
                           model, fuzzy_name, p, vce, cluster_var_name,
-                          fixed_fs, fs_coefs) {
-  function(data_b) {
+                          fixed_fs, fs_coefs,
+                          fixed_ps = FALSE,
+                          original_pscore = NULL,
+                          original_comsup_idx = NULL) {
+  function(data_b, orig_idx) {
     x_b  <- data_b[[running_name]] - cutoff
     G_b  <- data_b[[G_name]]
     y_b  <- data_b[[outcome_name]]
@@ -507,9 +525,19 @@ make_boot_rep <- function(outcome_name, running_name, cutoff, bwidth,
     kwt_b <- kernel_weights(x_b, bwidth, kernel, obs_wt_b)
 
     if (!noipsw && length(balance_names) > 0) {
-      bal_b   <- data_b[, balance_names, drop = FALSE]
-      ps_b    <- compute_pscore(G_b, bal_b, within_b, touse_b,
+      if (fixed_ps) {
+        # Look up original-sample propensity score and common-support mask
+        # via the orig_idx mapping (each resampled row carries its original
+        # row index).
+        ps_b <- list(
+          pscore     = original_pscore[orig_idx],
+          comsup_idx = original_comsup_idx[orig_idx]
+        )
+      } else {
+        bal_b <- data_b[, balance_names, drop = FALSE]
+        ps_b  <- compute_pscore(G_b, bal_b, within_b, touse_b,
                                 obs_wt_b, ps_model, comsup)
+      }
       ipw_b   <- compute_ipw_weights(G_b, ps_b$pscore, within_b, touse_b,
                                      ps_b$comsup_idx, m, obs_wt_b)
       fw_b    <- ipw_b$ipw * kwt_b
@@ -590,13 +618,14 @@ print.wsga <- function(x, ...) {
   cat(sep)
 
   if (use_boot) {
+    ps_tag <- if (isTRUE(x$fixed_ps)) " [PS fixed]" else ""
     if (!is.null(x$bootstrap$N_clusters)) {
       total_reps <- x$bootstrap$B_ok + x$bootstrap$failed
-      cat(sprintf("Cluster bootstrap: %d/%d reps, clustered on '%s' (%d clusters)\n",
+      cat(sprintf("Cluster bootstrap: %d/%d reps, clustered on '%s' (%d clusters)%s\n",
                   x$bootstrap$B_ok, total_reps,
-                  x$cluster_var_name, x$bootstrap$N_clusters))
+                  x$cluster_var_name, x$bootstrap$N_clusters, ps_tag))
     } else {
-      cat(sprintf("Bootstrap replications: %d\n", x$bootstrap$B_ok))
+      cat(sprintf("Bootstrap replications: %d%s\n", x$bootstrap$B_ok, ps_tag))
     }
   }
 

--- a/man/wsga.Rd
+++ b/man/wsga.Rd
@@ -26,6 +26,7 @@ wsga(
   inference = NULL,
   block_var = NULL,
   fixed_fs = FALSE,
+  fixed_ps = FALSE,
   seed = NULL,
   vce = "HC1",
   cluster_var = NULL,
@@ -117,6 +118,17 @@ must be constant within each cluster (validated at runtime).}
 \item{fixed_fs}{Logical. Fixed first-stage bootstrap for IV: bootstrap the
 reduced form and divide by the point-estimate first-stage coefficients.
 Default \code{FALSE}.}
+
+\item{fixed_ps}{Logical. Diagnostic flag. When \code{TRUE}, the propensity score
+model is \strong{not} refit inside the bootstrap loop; instead, each
+resampled row inherits the propensity score (and common-support
+membership) from its original-sample row. This isolates the
+variance contribution of the outcome model from that of the
+weight-estimation step. \strong{It understates the SE relative to the
+paper's intended interpretation}, which is why the default is
+\code{FALSE}. Useful for sanity-checking and for fast iteration on the
+outcome specification when the PS fit is expensive. No effect when
+\code{noipsw = TRUE} or when there are no balance variables.}
 
 \item{seed}{Integer or \code{NULL}. RNG seed for reproducibility. Default \code{NULL}.}
 

--- a/tests/testthat/test-cluster-bootstrap.R
+++ b/tests/testthat/test-cluster-bootstrap.R
@@ -27,17 +27,22 @@ test_that("row-level bootstrap (cluster_var = NULL) does not expose N_clusters",
   expect_null(fit$cluster_var_name)
 })
 
-test_that("build_cluster_rep_data assigns fresh IDs per draw", {
+test_that("build_cluster_rep_data assigns fresh IDs per draw and returns orig_idx", {
   d <- data.frame(school = c("A", "A", "B", "B", "C"),
                   y      = 1:5)
   out <- build_cluster_rep_data(d, "school", d$school,
                                 drawn = c("A", "A", "B"))
+  # Returns a list with data + orig_idx
+  expect_named(out, c("data", "orig_idx"))
   # A drawn twice → two distinct fresh IDs; B drawn once
-  expect_equal(length(unique(out$school)), 3L)
-  expect_true(all(grepl("__d[0-9]+$", out$school)))
+  expect_equal(length(unique(out$data$school)), 3L)
+  expect_true(all(grepl("__d[0-9]+$", out$data$school)))
   # Original outcomes preserved (each A row appears twice in the resample)
-  expect_equal(sum(out$y %in% c(1, 2)), 4L)  # 2 A rows × 2 draws
-  expect_equal(sum(out$y %in% c(3, 4)), 2L)  # 2 B rows × 1 draw
+  expect_equal(sum(out$data$y %in% c(1, 2)), 4L)  # 2 A rows × 2 draws
+  expect_equal(sum(out$data$y %in% c(3, 4)), 2L)  # 2 B rows × 1 draw
+  # orig_idx maps resampled rows back to original row indices
+  expect_equal(length(out$orig_idx), nrow(out$data))
+  expect_equal(out$orig_idx, c(1L, 2L, 1L, 2L, 3L, 4L))
 })
 
 test_that("cluster_resample with strata respects strata sizes", {

--- a/tests/testthat/test-fixed-ps.R
+++ b/tests/testthat/test-fixed-ps.R
@@ -1,0 +1,68 @@
+data(rddsga_synth)
+
+test_that("fixed_ps default is FALSE; output records it", {
+  fit_default <- wsga(y ~ m | sgroup, data = rddsga_synth,
+                      running = ~ x, bwidth = 0.5,
+                      bootstrap = TRUE, bsreps = 20, seed = 1)
+  expect_false(fit_default$fixed_ps)
+})
+
+test_that("fixed_ps = TRUE flips the recorded flag and runs cleanly", {
+  fit_fixed <- wsga(y ~ m | sgroup, data = rddsga_synth,
+                    running = ~ x, bwidth = 0.5,
+                    bootstrap = TRUE, bsreps = 20, seed = 1,
+                    fixed_ps = TRUE)
+  expect_true(fit_fixed$fixed_ps)
+  expect_equal(nrow(fit_fixed$bootstrap$draws), 20L)
+})
+
+test_that("fixed_ps changes the bootstrap distribution vs. refit-per-rep", {
+  fit_refit <- wsga(y ~ m | sgroup, data = rddsga_synth,
+                    running = ~ x, bwidth = 0.5,
+                    bootstrap = TRUE, bsreps = 50, seed = 7,
+                    fixed_ps = FALSE)
+  fit_fixed <- wsga(y ~ m | sgroup, data = rddsga_synth,
+                    running = ~ x, bwidth = 0.5,
+                    bootstrap = TRUE, bsreps = 50, seed = 7,
+                    fixed_ps = TRUE)
+  # Point estimates are identical (PS is computed once on the original sample
+  # in both cases, and the bootstrap inherits that fit when fixed_ps = FALSE
+  # only inside the loop)
+  expect_equal(fit_refit$coefficients, fit_fixed$coefficients)
+  # Draws differ — fixed_ps doesn't refit the logit on each replicate
+  expect_false(isTRUE(all.equal(fit_refit$bootstrap$draws,
+                                fit_fixed$bootstrap$draws)))
+})
+
+test_that("fixed_ps is reproducible under seed", {
+  fit_a <- wsga(y ~ m | sgroup, data = rddsga_synth,
+                running = ~ x, bwidth = 0.5,
+                bootstrap = TRUE, bsreps = 20, seed = 42,
+                fixed_ps = TRUE)
+  fit_b <- wsga(y ~ m | sgroup, data = rddsga_synth,
+                running = ~ x, bwidth = 0.5,
+                bootstrap = TRUE, bsreps = 20, seed = 42,
+                fixed_ps = TRUE)
+  expect_equal(fit_a$bootstrap$draws, fit_b$bootstrap$draws)
+})
+
+test_that("fixed_ps works alongside cluster bootstrap", {
+  set.seed(1)
+  d <- rddsga_synth
+  d$school <- sample.int(50, nrow(d), replace = TRUE)
+  fit <- wsga(y ~ m | sgroup, data = d,
+              running = ~ x, bwidth = 0.5,
+              bootstrap = TRUE, bsreps = 20, seed = 5,
+              cluster_var = "school", fixed_ps = TRUE)
+  expect_true(fit$fixed_ps)
+  expect_equal(fit$bootstrap$N_clusters, 50L)
+})
+
+test_that("print method tags [PS fixed] when fixed_ps = TRUE", {
+  fit <- wsga(y ~ m | sgroup, data = rddsga_synth,
+              running = ~ x, bwidth = 0.5,
+              bootstrap = TRUE, bsreps = 10, seed = 1,
+              fixed_ps = TRUE)
+  out <- capture.output(print(fit))
+  expect_true(any(grepl("\\[PS fixed\\]", out)))
+})


### PR DESCRIPTION
## Summary

Implements **Q3** of the wsga design plan: an opt-in `fixed_ps` flag that holds the propensity score at the original-sample fit and skips refitting inside the bootstrap loop. Default remains `FALSE` (paper-intended behavior — bootstrap variance reflects PS estimation uncertainty). When `TRUE`, the resulting SEs intentionally **understate** total variance.

Originally drafted as a stacked PR on top of #6; that merged while this branch was being prepared, so this PR targets `main` directly. Linear history, no rebase needed.

## Why expose this flag

Two non-default uses:

1. **Variance decomposition.** Comparing SEs with `fixed_ps = TRUE` vs `FALSE` tells you how much of the total variance comes from the PS step vs the outcome model.
2. **Iteration speed.** When the PS fit is expensive (high-dimensional moderators, large N), `fixed_ps = TRUE` makes each bootstrap rep roughly half as costly — useful while iterating on the outcome specification before doing the final inference run with the flag off.

## What's in here

- `build_cluster_rep_data()` and the row-level resampler now both return `list(data, orig_idx)`. `orig_idx[k]` is the original-data row index for the k-th resampled row.
- `make_boot_rep()` closure signature widened to `function(data_b, orig_idx)`. When `fixed_ps = TRUE` and PS is in play, the closure builds `ps_b$pscore = original_pscore[orig_idx]` and `ps_b$comsup_idx = original_comsup_idx[orig_idx]` instead of calling `compute_pscore()` again.
- `print.wsga` appends `[PS fixed]` to the bootstrap footer when the flag is on.
- Output object gains a `fixed_ps` field.
- 6 new tests in `test-fixed-ps.R`; one existing cluster-bootstrap test updated for the new resampler return shape.

## What's deliberately not in here

- Any change to default behavior. The flag defaults to `FALSE`; existing callers are unaffected.
- A runtime warning when `fixed_ps = TRUE` and SEs come out small. The docstring is the documentation; we don't need nags.

## Test plan

- [x] All existing tests pass (including PR #6's cluster-bootstrap tests under the updated resampler shape).
- [x] 6 new tests in `test-fixed-ps.R` cover: default flag value, flag-as-recorded, identical point estimates with/without flag, different bootstrap draws under same seed, reproducibility under seed, cluster-bootstrap compatibility, and `print.wsga` annotation.
- [ ] CI green (will run on push).

## Related

- Q3 of `project_wsga_design` memory.
- Completes Q1–Q7 of the bootstrap design. The next major chunk is the **DiD scaffolding** (Q8–Q10): `design = "did"`, `unit`/`time`/`treat`/`post_value` args, long-form TWFE design matrix, DiD-specific balance tables, sharp-DiD-only enforcement.