### PR TITLE
docs: fill DiD documentation gaps (closes #15)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,42 @@
+# wsga (R package) NEWS
+
+## wsga 0.7.0 (2026-05-11)
+
+### New features
+
+- **`design = "did"`**: sharp 2-period DiD-SGA pipeline. New required arguments `unit`, `time`, `treat`; optional `post_value` (defaults to `max(time)`). Runs long-form TWFE with subgroup × post interactions, IPW reweighting, and pairs cluster bootstrap over units (Cameron-Gelbach-Miller) by default.
+- **`inference` argument**: three-mode inference — `"empirical"` (default with bootstrap, percentile CIs), `"normal"` (normal-approx from bootstrap SE), `"analytical"` (sandwich/cluster-robust, no bootstrap).
+- **`fixed_ps`**: opt-in flag to hold the propensity score fixed at the original-sample fit across bootstrap replicates. Useful for variance decomposition. Default `FALSE`.
+- **`cluster_var`**: drives both analytical SEs and the bootstrap. DiD defaults to clustering on `unit`. One-time warning when fewer than 30 unique clusters are present.
+- **Bundled dataset**: `wsga_did_synth` — balanced 2-period panel of 500 units (seed = 7). True effects `tau_0 = 1`, `tau_1 = 3`.
+- **DiD balance tables**: aggregate and treated-only (D = 1) balance, each unweighted and IPW-weighted.
+- **Vignette**: `vignette("wsga-did-intro")` walks through the full DiD workflow.
+- **`bsreps` default** bumped 50 → 200.
+
+### Breaking changes
+
+- Balance accessor: `fit$balance$unweighted$table` → `fit$balance$unweighted$aggregate$table` (nested structure to accommodate the DiD treated-only block).
+- Default `bsreps` changed from 50 to 200.
+
+### Package rename (from rddsga)
+
+- Package renamed `rddsga` → `wsga`. The old function `rddsga()` is retained as a deprecated alias forwarded to `wsga()`. Plan to remove in v2.
+
+---
+
+## rddsga 0.3.0 → wsga 0.6.x (internal milestones)
+
+- Umbrella refactor: single `wsga()` entry point dispatching both RD and (now) DiD paths.
+- S3 methods: `print`, `summary`, `coef`, `vcov`, `confint`, `nobs`.
+- `block_var` stratification for the bootstrap.
+- `seed` argument for reproducible bootstrap draws.
+- `fixed_fs` for fuzzy RD: hold first-stage estimate fixed across bootstrap reps.
+- Three kernel types: uniform, triangular, Epanechnikov.
+
+---
+
+## rddsga 0.2.x / 0.3.0 (2018–2023)
+
+Initial CRAN-adjacent R implementation of the RDD-SGA estimator accompanying
+the working paper "Weighted Subgroup Analysis in Regression Discontinuity
+Designs" (Carril, Cazor, Gerardino, Litschig, Pomeranz).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Implements inverse probability weighted (IPW) subgroup analysis for research designs that require control variables for identification. When subgroups differ in observed moderators, a naive comparison of subgroup-specific treatment effects conflates the causal effect of the subgroup characteristic with the effect of correlated moderators. Reweighting observations via IPW balances observed moderators across subgroups, isolating the subgroup-attributable component of the treatment effect difference.
 
-Both a **Stata** package and an **R** package are included in this repository. Currently both implement weighted subgroup analysis for **regression discontinuity (RD)** designs; **sharp difference-in-differences (DiD)** support is planned.
+Both a **Stata** package and an **R** package are included in this repository. Both implement weighted subgroup analysis for **regression discontinuity (RD)** designs (sharp and fuzzy) and **sharp 2-period difference-in-differences (DiD)**.
 
 ---
 
@@ -19,11 +19,18 @@ net install wsga
 net get wsga
 ```
 
-### Quick start
+### Quick start (RD)
 
 ```stata
 use rddsga_synth
 wsga Y Z X1 X2, sgroup(G) bwidth(10) reducedform bsreps(200)
+```
+
+### Quick start (DiD)
+
+```stata
+use wsga_did_synth
+wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) bsreps(200)
 ```
 
 See `help wsga` for full documentation. The previous command name `rddsga` is retained as a deprecated alias and is installed alongside `wsga`.
@@ -38,13 +45,12 @@ See `help wsga` for full documentation. The previous command name `rddsga` is re
 devtools::install_github("acarril/wsga")
 ```
 
-### Quick start
+### Quick start (RD)
 
 ```r
 library(wsga)
 data(rddsga_synth)
 
-# Sharp RD with IPW balancing moderator m, bootstrap SEs
 fit <- wsga(
   y ~ m | sgroup,
   data    = rddsga_synth,
@@ -57,7 +63,27 @@ print(fit)
 summary(fit)   # also shows balance tables
 ```
 
-See `?wsga` and `vignette("wsga-intro")` for full documentation. The previous function name `rddsga()` is retained as a deprecated alias.
+### Quick start (DiD)
+
+```r
+library(wsga)
+data(wsga_did_synth)
+
+fit <- wsga(
+  y ~ m | sgroup,
+  data   = wsga_did_synth,
+  design = "did",
+  unit   = "unit",
+  time   = "time",
+  treat  = "D",
+  bsreps = 200,
+  seed   = 42
+)
+print(fit)
+summary(fit)   # shows aggregate and treated-only balance tables
+```
+
+See `?wsga`, `vignette("wsga-intro")`, and `vignette("wsga-did-intro")` for full documentation. The previous function name `rddsga()` is retained as a deprecated alias.
 
 ---
 

--- a/stata/rddsga.pkg
+++ b/stata/rddsga.pkg
@@ -33,3 +33,4 @@ F wsga.sthlp
 F rddsga.ado
 F rddsga.sthlp
 f rddsga_synth.dta
+f wsga_did_synth.dta

--- a/stata/wsga.pkg
+++ b/stata/wsga.pkg
@@ -2,9 +2,9 @@ v 1.2.0
 d 'WSGA': Weighted subgroup analysis
 d
 d  wsga conducts weighted subgroup analysis for research designs that
-d  require control variables for identification. Currently it supports
-d  regression discontinuity (RD) designs (sharp and fuzzy); sharp
-d  difference-in-differences (DiD) is planned. Observations in each
+d  require control variables for identification. It supports regression
+d  discontinuity (RD) designs (sharp and fuzzy) and sharp 2-period
+d  difference-in-differences (DiD). Observations in each
 d  subgroup are weighted by the inverse of their conditional probabilities
 d  to belong to that subgroup, given a set of moderators. Analyzing the
 d  differential treatment effect in the reweighted sample helps isolate the
@@ -38,3 +38,4 @@ F wsga.sthlp
 F rddsga.ado
 F rddsga.sthlp
 f rddsga_synth.dta
+f wsga_did_synth.dta

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -1,56 +1,75 @@
 {smcl}
-{* *! version 1.2.0 2026-05-09}{...}
+{* *! version 1.3.0 2026-05-11}{...}
 {title:Title}
 
 {pstd}
-{hi:wsga} {hline 2} Weighted subgroup analysis (regression discontinuity; sharp difference-in-differences planned)
+{hi:wsga} {hline 2} Weighted subgroup analysis (regression discontinuity and difference-in-differences)
 
 
 {title:Syntax}
 
+{pstd}
+{ul:Regression discontinuity (RD) design} (default):
+
 {p 8 16 2}
 {cmd:wsga} {depvar} {it:assignvar} [{indepvars}] {ifin}
-{cmd:,} {it:options}
+{cmd:,} {opt sg:roup(varname)} {opt bw:idth(real)} [{it:rdd_options} {it:common_options}]
+{p_end}
+
+{pstd}
+{ul:Difference-in-differences (DiD) design}:
+
+{p 8 16 2}
+{cmd:wsga} {depvar} [{indepvars}] {ifin}
+{cmd:,} {opt sg:roup(varname)} {opt des:ign(did)} {opt un:it(varname)} {opt ti:me(varname)} {opt tr:eat(varname)} [{it:did_options} {it:common_options}]
 {p_end}
 
 {phang}
-{it:depvar} is the outcome variable, {it:assignvar} is the assignment (running) variable for which there is a known cutoff, and {it:indepvars} are optional control variables included in the outcome regression.
-{p_end}
+For RD: {it:depvar} is the outcome; {it:assignvar} is the running variable with a known cutoff; {it:indepvars} are optional control/balance variables.{p_end}
+{phang}
+For DiD: {it:depvar} is the outcome; {it:indepvars} are optional covariates included in the outcome regression and used in the propensity score model.{p_end}
 
-{synoptset 24 tabbed}{...}
+{synoptset 26 tabbed}{...}
 {synopthdr}
 {synoptline}
-{syntab :Subgroup and RDD}
-{p2coldent:* {opth sg:roup(varname)}}binary subgroup indicator variable (must be 0/1){p_end}
-{synopt :{opth f:uzzy(varname)}}actual treatment status indicator for fuzzy RD; if not specified, sharp RD is assumed{p_end}
+{syntab :Design (required)}
+{p2coldent:* {opth sg:roup(varname)}}binary (0/1) subgroup indicator variable{p_end}
+{synopt :{opt des:ign(string)}}{opt rdd} (default) or {opt did}; selects the estimation pipeline{p_end}
+
+{syntab :RDD-specific options}
+{p2coldent:* {opt bw:idth(real)}}symmetric bandwidth around the cutoff; required for {opt design(rdd)}{p_end}
+{synopt :{opth f:uzzy(varname)}}actual treatment receipt for fuzzy RD; if omitted, sharp RD is assumed{p_end}
 {synopt :{opt c:utoff(real)}}cutoff value in {it:assignvar}; default is {opt cutoff(0)}{p_end}
-{p2coldent:* {opt bw:idth(real)}}symmetric bandwidth around the cutoff{p_end}
-{synopt :{opt k:ernel(kernelfn)}}kernel function for local-polynomial estimation; {opt uniform} (default), {opt triangular}, or {opt epanechnikov}{p_end}
-{synopt :{opt p:(int)}}order of the local polynomial; default is {opt p(1)}{p_end}
+{synopt :{opt k:ernel(kernelfn)}}kernel function: {opt uniform} (default), {opt triangular}, or {opt epanechnikov}{p_end}
+{synopt :{opt p:(int)}}polynomial order; default is {opt p(1)} (local linear){p_end}
+{synopt :{opt first:stage}}estimate the first stage (discontinuity in treatment probability){p_end}
+{synopt :{opt reduced:form}}estimate the reduced form RD effect{p_end}
+{synopt :{opt iv:regress}}estimate the treatment effect via 2SLS; requires {opt fuzzy(varname)}{p_end}
+{synopt :{opt fixed:bootstrap}}for fuzzy RD: bootstrap the reduced form only and divide by the fixed first-stage estimate{p_end}
+
+{syntab :DiD-specific options}
+{p2coldent:* {opt un:it(varname)}}panel unit identifier; required for {opt design(did)}{p_end}
+{p2coldent:* {opt ti:me(varname)}}time variable (must have exactly 2 unique values); required for {opt design(did)}{p_end}
+{p2coldent:* {opt tr:eat(varname)}}binary treatment indicator (unit-constant); required for {opt design(did)}{p_end}
+{synopt :{opt post:_value(string)}}value of {opt time()} denoting the post period; default is the larger of the two values{p_end}
 
 {syntab :Balance and weighting}
 {p2coldent:+ {opth bal:ance(varlist)}}variables entering the propensity score model; default is {it:indepvars}{p_end}
 {synopt :{opt probit}}estimate propensity score with {manhelp probit R:probit}; default is {manhelp logit R:logit}{p_end}
 {synopt :{opt com:sup}}restrict sample to common propensity score support{p_end}
-{synopt :{opt m:(int)}}weighting mode: {opt m(2)} (default) balances both subgroups toward the pooled distribution; {opt m(1)} weights group 1 toward group 0; {opt m(0)} weights group 0 toward group 1{p_end}
-{synopt :{opt rbal:ance:(int)}}how conditional means are computed for balance tables: {opt rbalance(0)} (default) evaluates at the cutoff; {opt rbalance(1)} uses the within-bandwidth sample mean{p_end}
-{synopt :{opt noipsw}}skip inverse propensity score weighting entirely{p_end}
-{synopt :{opt dibal:ance}}display unweighted and IPSW balance tables{p_end}
+{synopt :{opt m:(int)}}weighting mode: {opt m(2)} (default) balances both subgroups toward the pooled distribution; {opt m(1)} weights G=1 toward G=0; {opt m(0)} weights G=0 toward G=1{p_end}
+{synopt :{opt rbal:ance(int)}}conditional mean method for RD balance tables: {opt rbalance(0)} (default) extrapolates to the cutoff; {opt rbalance(1)} uses the within-bandwidth mean{p_end}
+{synopt :{opt noipsw}}skip IPW entirely; subgroup estimates are computed without reweighting{p_end}
+{synopt :{opt dibal:ance}}display unweighted and IPW-weighted balance tables{p_end}
 {synopt :{opth ipsw:eight(newvar)}}save IPW weights to a new variable{p_end}
 {synopt :{opth psc:ore(newvar)}}save propensity scores to a new variable{p_end}
 
-{syntab :Model}
-{synopt :{opt first:stage}}estimate the first stage (discontinuity in treatment probability){p_end}
-{synopt :{opt reduced:form}}estimate the reduced form effect{p_end}
-{synopt :{opt iv:regress}}estimate the treatment effect via 2SLS; requires {opt fuzzy(varname)}{p_end}
-{synopt :{opth vce(vcetype)}}{it:vcetype} may be {opt r:obust}, {opt cl:uster} {it:clustvar}, or any option accepted by {manhelp regress R:regress}; default is {opt robust}{p_end}
-{synopt :{opt weights(weightsvar)}}optional observation weights multiplied into the kernel{p_end}
-
-{syntab :Bootstrap}
-{synopt :{opt noboot:strap}}suppress bootstrap standard errors; use sandwich SEs only{p_end}
-{synopt :{opt bsr:eps(#)}}number of bootstrap replications; default is {opt bsreps(50)}{p_end}
+{syntab :Inference}
+{synopt :{opth vce(vcetype)}}analytical variance estimator; default is {opt robust}; see {help vce_option}{p_end}
+{synopt :{opt weights(weightsvar)}}optional observation weights multiplied into the kernel (RDD) or used as frequency weights (DiD){p_end}
+{synopt :{opt noboot:strap}}suppress bootstrap standard errors; use analytical SEs only{p_end}
+{synopt :{opt bsr:eps(#)}}bootstrap replications; default is {opt bsreps(50)}{p_end}
 {synopt :{opt norm:al}}report normal-approximation p-values and CIs instead of empirical (percentile){p_end}
-{synopt :{opt fixed:bootstrap}}for fuzzy RD: bootstrap the reduced form only and divide by the fixed first-stage point estimate{p_end}
 {synopt :{opt block:bootstrap(varname)}}stratified bootstrap: resample within strata defined by {it:varname}{p_end}
 {synoptline}
 {p2colreset}{...}
@@ -63,30 +82,46 @@
 {title:Description}
 
 {pstd}
-{cmd:wsga} conducts binary subgroup analysis in regression discontinuity (RD) settings using inverse propensity score weighting (IPSW).
-Observations in each subgroup are reweighted by the inverse of their estimated probability of belonging to that subgroup, given a set of observed moderators.
-This ensures that the two subgroups have the same distribution of observed moderators at the cutoff, so that any remaining difference in subgroup RD estimates can be attributed to the subgroup characteristic rather than to correlated moderators.
+{cmd:wsga} conducts binary subgroup analysis using inverse propensity score weighting (IPSW) in two research designs.
 
 {pstd}
-The propensity score is estimated via {manhelp logit R:logit} (default) or {manhelp probit R:probit} using {it:indepvars}, or a separate set specified with {opt balance(varlist)}.
-Three weighting modes are available via {opt m()}: {opt m(2)} (default) targets the pooled distribution; {opt m(1)} and {opt m(0)} are ATT-style modes targeting group 0 and group 1 respectively.
+{ul:Regression discontinuity ({opt design(rdd)}, default).}
+Observations near the cutoff in each subgroup are reweighted so that the two subgroups have the same distribution of observed moderators at the cutoff.
+Any remaining difference in per-subgroup RD estimates can therefore be attributed to the subgroup characteristic rather than correlated moderators.
+{cmd:wsga} supports sharp RD ({opt reducedform}), the first stage of a fuzzy RD ({opt firststage}), and fuzzy RD via 2SLS ({opt ivregress}).
 
 {pstd}
-Estimation supports sharp RD ({opt reducedform}), the first stage of a fuzzy RD ({opt firststage}), and fuzzy RD via 2SLS ({opt ivregress}).
-All three estimators report per-subgroup RD gaps and their difference.
-By default, standard errors are bootstrap-based with empirical p-values and percentile confidence intervals; the {opt normal} option switches to normal-approximation inference.
+{ul:Difference-in-differences ({opt design(did)}).}
+For a balanced 2-period panel, {cmd:wsga} runs a long-form two-way fixed effects (TWFE) regression with subgroup × post-treatment interactions.
+IPW reweighting ensures the two subgroups have the same distribution of observed moderators, so the difference in DiD estimates is attributable to the subgroup characteristic.
+Treatment must be binary, sharp, and unit-constant; fuzzy DiD is not supported.
+{opt design(did)} requires {opt unit()}, {opt time()}, and {opt treat()}.
 
 {pstd}
-Balance tables report the standardized mean difference and p-value for each covariate, plus a joint F-statistic, for both the unweighted and IPW-weighted samples.
+{ul:Common features.}
+The propensity score for subgroup membership is estimated via {manhelp logit R:logit} (default) or {manhelp probit R:probit} on {it:indepvars}, or a separate set specified with {opt balance(varlist)}.
+Three weighting modes are available via {opt m()}: {opt m(2)} (default) targets the pooled distribution; {opt m(1)} and {opt m(0)} are ATT-style modes.
+Standard errors are bootstrap-based by default (empirical p-values and percentile CIs); the {opt normal} option switches to normal-approximation inference; {opt nobootstrap} uses the analytical sandwich estimator only.
+Balance tables report the standardized mean difference and joint F-statistic for both the unweighted and IPW-weighted samples.
+For {opt design(did)}, a second balance table restricted to treated units (D=1) is also reported.
 
 
 {marker options}{...}
 {title:Options}
 
-{dlgtab:Subgroup and RDD}
+{dlgtab:Design (required)}
 
 {phang}
-{opt sgroup(varname)} binary (0/1) subgroup indicator. Required.
+{opt sgroup(varname)} binary (0/1) subgroup indicator. Required for all designs.
+
+{phang}
+{opt design(string)} selects the estimation pipeline. {opt rdd} (default) runs the regression discontinuity path; {opt did} runs the 2-period difference-in-differences path.
+
+
+{dlgtab:RDD-specific options}
+
+{phang}
+{opt bwidth(real)} symmetric bandwidth around the cutoff. Required for {opt design(rdd)}.
 
 {phang}
 {opt fuzzy(varname)} actual treatment receipt indicator for fuzzy RD. Required when {opt ivregress} or {opt firststage} is specified.
@@ -95,13 +130,37 @@ Balance tables report the standardized mean difference and p-value for each cova
 {opt cutoff(real)} cutoff value of {it:assignvar}; default is {opt cutoff(0)}.
 
 {phang}
-{opt bwidth(real)} symmetric bandwidth around the cutoff. Required.
-
-{phang}
 {opt kernel(kernelfn)} kernel for local-polynomial weighting: {opt uniform} (default), {opt triangular}, or {opt epanechnikov}.
 
 {phang}
 {opt p(int)} polynomial order; default is {opt p(1)} (local linear).
+
+{phang}
+{opt firststage} estimates the discontinuity in treatment probability (first stage of a fuzzy RD).
+
+{phang}
+{opt reducedform} estimates the reduced form RD effect on the outcome.
+
+{phang}
+{opt ivregress} estimates the treatment effect using 2SLS. Requires {opt fuzzy(varname)}.
+
+{phang}
+{opt fixedbootstrap} for fuzzy RD: bootstrap the reduced form only and divide by the fixed first-stage point estimate.
+
+
+{dlgtab:DiD-specific options}
+
+{phang}
+{opt unit(varname)} panel unit identifier. Required for {opt design(did)}.
+
+{phang}
+{opt time(varname)} time variable. Must have exactly two unique non-missing values. Required for {opt design(did)}.
+
+{phang}
+{opt treat(varname)} binary treatment indicator. Must be unit-constant (same value in both periods for every unit). Required for {opt design(did)}.
+
+{phang}
+{opt post_value(string)} value of {opt time()} that denotes the post period. Defaults to the larger of the two time values.
 
 
 {dlgtab:Balance and weighting}
@@ -124,8 +183,8 @@ Required if {it:indepvars} is empty and IPSW is in use.
 {opt m(0)}: weights group 0 toward the distribution of group 1.
 
 {phang}
-{opt rbalance(int)} method for computing conditional means in balance tables.
-{opt rbalance(0)} (default): extrapolates to the cutoff via local linear regression within each subgroup.
+{opt rbalance(int)} method for computing conditional means in RD balance tables.
+{opt rbalance(0)} (default): extrapolates to the cutoff via local linear regression.
 {opt rbalance(1)}: uses within-bandwidth sample means.
 
 {phang}
@@ -141,25 +200,14 @@ Required if {it:indepvars} is empty and IPSW is in use.
 {opt pscore(newvar)} save propensity scores to a new variable.
 
 
-{dlgtab:Model}
+{dlgtab:Inference}
 
 {phang}
-{opt firststage} estimates the discontinuity in treatment probability (first stage).
+{opt vce(vcetype)} analytical variance estimator; default is {opt robust}. See {help vce_option}.
+For {opt design(did)} with a {opt unit()} variable, the default upgrades to {opt vce(cluster unit)}.
 
 {phang}
-{opt reducedform} estimates the reduced form RD effect on the outcome.
-
-{phang}
-{opt ivregress} estimates the treatment effect using 2SLS. Requires {opt fuzzy(varname)}.
-
-{phang}
-{opt vce(vcetype)} variance estimator; default is {opt robust}. See {help vce_option}.
-
-{phang}
-{opt weights(weightsvar)} optional observation-level weights multiplied into the kernel weights.
-
-
-{dlgtab:Bootstrap}
+{opt weights(weightsvar)} optional observation-level weights.
 
 {phang}
 {opt nobootstrap} suppress bootstrap variance estimation; use the sandwich estimator from {opt vce()} only.
@@ -172,16 +220,16 @@ Required if {it:indepvars} is empty and IPSW is in use.
 By default {cmd:wsga} uses the percentile method: the empirical p-value is the share of bootstrap draws with |coef| >= |estimate|, and CIs are the 2.5th/97.5th percentiles of the bootstrap distribution.
 
 {phang}
-{opt fixedbootstrap} for fuzzy RD: bootstrap the reduced form only and divide by the fixed first-stage point estimate.
-
-{phang}
 {opt blockbootstrap(varname)} stratified bootstrap: resample within strata defined by {it:varname}.
+For {opt design(did)}, the bootstrap is a pairs-cluster bootstrap over units (Cameron-Gelbach-Miller); {opt blockbootstrap()} adds an additional stratification layer within that.
 
 
 {marker examples}{...}
 {title:Examples}
 
-{pstd}Load synthetic dataset{p_end}
+{pstd}{ul:Regression discontinuity}
+
+{pstd}Load RD synthetic dataset{p_end}
 {phang2}{cmd:. use rddsga_synth}{p_end}
 
 {pstd}Assess covariate balance and display balance tables{p_end}
@@ -196,6 +244,20 @@ By default {cmd:wsga} uses the percentile method: the empirical p-value is the s
 {pstd}Sharp RD without IPW{p_end}
 {phang2}{cmd:. wsga Y Z, sgroup(G) bwidth(10) reducedform noipsw nobootstrap}{p_end}
 
+{pstd}{ul:Difference-in-differences}
+
+{pstd}Load DiD synthetic panel dataset (500 units, 2 periods){p_end}
+{phang2}{cmd:. use wsga_did_synth}{p_end}
+
+{pstd}Unweighted DiD subgroup analysis (no IPW){p_end}
+{phang2}{cmd:. wsga y, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) noipsw}{p_end}
+
+{pstd}IPW-weighted DiD balancing on moderator m, display balance tables{p_end}
+{phang2}{cmd:. wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) dibalance}{p_end}
+
+{pstd}DiD with 200 cluster bootstrap replications{p_end}
+{phang2}{cmd:. wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) bsreps(200)}{p_end}
+
 
 {marker results}{...}
 {title:Stored results}
@@ -203,8 +265,8 @@ By default {cmd:wsga} uses the percentile method: the empirical p-value is the s
 {pstd}
 {cmd:wsga} stores the following in {cmd:e()}:
 
-{synoptset 24 tabbed}{...}
-{p2col 5 24 28 2: Scalars}{p_end}
+{synoptset 28 tabbed}{...}
+{p2col 5 28 32 2: Scalars}{p_end}
 {synopt:{cmd:e(unw_N_G0)}}observations in subgroup 0 (unweighted){p_end}
 {synopt:{cmd:e(unw_N_G1)}}observations in subgroup 1 (unweighted){p_end}
 {synopt:{cmd:e(unw_Fstat)}}joint F-statistic (unweighted){p_end}
@@ -222,17 +284,22 @@ By default {cmd:wsga} uses the percentile method: the empirical p-value is the s
 {synopt:{cmd:e(ub_g0)}}bootstrap CI upper bound, subgroup 0{p_end}
 {synopt:{cmd:e(lb_g1)}}bootstrap CI lower bound, subgroup 1{p_end}
 {synopt:{cmd:e(ub_g1)}}bootstrap CI upper bound, subgroup 1{p_end}
+{synopt:{cmd:e(design)}}design in use: {cmd:rdd} or {cmd:did}{p_end}
+{synopt:{cmd:e(N_units)}}({opt design(did)} only) number of unique panel units{p_end}
+{synopt:{cmd:e(N_clusters)}}number of clusters used in a cluster bootstrap{p_end}
 
-{p2col 5 24 28 2: Matrices}{p_end}
-{synopt:{cmd:e(b)}}subgroup RD coefficient vector (G=0, G=1){p_end}
+{p2col 5 28 32 2: Matrices}{p_end}
+{synopt:{cmd:e(b)}}subgroup coefficient vector (G=0, G=1){p_end}
 {synopt:{cmd:e(V)}}variance-covariance matrix{p_end}
-{synopt:{cmd:e(unw)}}balance table matrix (unweighted){p_end}
-{synopt:{cmd:e(ipsw)}}balance table matrix (IPW){p_end}
+{synopt:{cmd:e(unw)}}aggregate balance table (unweighted){p_end}
+{synopt:{cmd:e(ipsw)}}aggregate balance table (IPW){p_end}
+{synopt:{cmd:e(unw_treated)}}({opt design(did)} only) treated-only balance table (unweighted){p_end}
+{synopt:{cmd:e(ipsw_treated)}}({opt design(did)} only) treated-only balance table (IPW){p_end}
 {p2colreset}{...}
 
 {pstd}
-Additionally, all scalars and macros from the underlying {opt reducedform}, {opt firststage}, or {opt ivregress} estimation are stored in {cmd:e()}.
-See {help regress##results:Stored Results} for details.
+Additionally, all scalars and macros from the underlying estimation command ({opt reducedform}/{opt firststage}/{opt ivregress} for RDD; {help xtreg:xtreg, fe} for DiD) are stored in {cmd:e()}.
+See {help regress##results:Stored Results} and {help xtreg##results:xtreg Stored Results} for details.
 
 
 {marker authors}{...}
@@ -271,3 +338,6 @@ Please report issues at {browse "https://github.com/acarril/wsga/issues"}.
 
 {phang}
 Carril, Alvaro, Andre Cazor, Maria Paula Gerardino, Stephan Litschig, and Dina Pomeranz. "Weighted Subgroup Analysis in Regression Discontinuity Designs." Working paper.{p_end}
+
+{phang}
+Cameron, A. Colin, Jonah B. Gelbach, and Douglas L. Miller. "Bootstrap-Based Improvements for Inference with Clustered Errors." {it:Review of Economics and Statistics} 90(3): 414-427, 2008.{p_end}


### PR DESCRIPTION
## Summary

- **`stata/wsga.sthlp`**: completely overhauled to cover `design(did)`. New dual-syntax block (RD vs DiD), updated description section, DiD-specific options (`unit`, `time`, `treat`, `post_value`), DiD examples using `wsga_did_synth`, additional stored results (`e(design)`, `e(N_units)`, `e(N_clusters)`, `e(unw_treated)`, `e(ipsw_treated)`), Cameron-Gelbach-Miller reference.
- **`stata/wsga.pkg` + `stata/rddsga.pkg`**: description no longer says DiD is "planned"; `wsga_did_synth.dta` added to the file manifest so `net install wsga` + `net get wsga` actually delivers the dataset.
- **`README.md`**: remove "planned" qualifier from the intro; add DiD quick-start blocks for both Stata and R; reference the `wsga-did-intro` vignette.
- **`NEWS.md`** (new file): covers the `rddsga` → `wsga` rename and full `v0.7.0` release notes for the R package.

## Test plan

- [ ] `help wsga` renders cleanly in Stata (no smcl parse errors)
- [ ] `net install wsga` + `net get wsga` from the branch delivers `wsga_did_synth.dta`
- [ ] README renders correctly on GitHub (both quick-start blocks)
- [ ] `NEWS.md` shows up on the repo root