### PR TITLE
fix(Stata): kernel-weight positional macro bug (closes #14)

### DIFF
--- a/stata/tests/smoke_rdd.do
+++ b/stata/tests/smoke_rdd.do
@@ -1,0 +1,44 @@
+// smoke_rdd.do — basic RDD smoke test for wsga
+// Run from rddsga-repo/:
+//   stata-mp -b do stata/tests/smoke_rdd.do && cat smoke_rdd.log
+//
+// Tests that all three kernel types run without error on rddsga_synth.dta
+// and that the uniform-kernel coefficient is in a plausible range.
+
+local ado_dir = subinstr(c(pwd), "", "", .)
+quietly do stata/wsga.ado
+
+use stata/rddsga_synth, clear
+
+local n_fail = 0
+
+foreach kernel in "" "kernel(triangular)" "kernel(epanechnikov)" {
+    local label = cond("`kernel'" == "", "uniform", "`kernel'")
+    capture wsga Y X, sgroup(G) bwidth(10) reducedform nobootstrap noipsw `kernel'
+    if _rc != 0 {
+        di as error "FAIL [`label']: rc=" _rc
+        local ++n_fail
+    }
+    else {
+        di as result "PASS [`label']"
+    }
+}
+
+// Sanity-check: G=0 coefficient should be non-missing and finite
+wsga Y X, sgroup(G) bwidth(10) reducedform nobootstrap noipsw
+scalar _b0 = e(b)[1,1]
+if mi(_b0) {
+    di as error "FAIL [coef check]: e(b)[1,1] is missing"
+    local ++n_fail
+}
+else {
+    di as result "PASS [coef check]: G=0 coef = " _b0
+}
+
+if `n_fail' == 0 {
+    di as result _newline "All smoke tests passed."
+}
+else {
+    di as error _newline "`n_fail' smoke test(s) FAILED."
+    exit 1
+}

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,4 +1,4 @@
-*! 1.3.0 Alvaro Carril 2026-05-11
+*! 1.3.1 Alvaro Carril 2026-05-11
 program define wsga, eclass
 version 11.1
 syntax varlist(min=1 numeric fv) [if] [in], ///
@@ -221,15 +221,15 @@ local kernel = "uni"
 
   if ("`kernel'"=="epanechnikov" | "`kernel'"=="epa") {
     local kernel_type = "Epanechnikov"
-    qui g double `kwt'=max(0,3/4*(`bwidthtab'^2-abs(`2')^2))*`oweights'
+    qui g double `kwt'=max(0,3/4*(`bwidthtab'^2-abs(`assignvar')^2))*`oweights'
   }
   else if ("`kernel'"=="triangular" | "`kernel'"=="tri") {
       local kernel_type = "Triangular"
-      qui g double `kwt'=max(0,`bwidthtab'-abs(`2'))*`oweights'
+      qui g double `kwt'=max(0,`bwidthtab'-abs(`assignvar'))*`oweights'
   }
   else {
     local kernel_type = "Uniform"
-    qui g double `kwt'=(-`bwidthtab'<=(`2') & `2'<`bwidthtab')*`oweights'
+    qui g double `kwt'=(-`bwidthtab'<=(`assignvar') & `assignvar'<`bwidthtab')*`oweights'
   }
        
 


### PR DESCRIPTION
Replaces kernel-weight lines using positional macro 2 with assignvar. Adds stata/tests/smoke_rdd.do.