### PR TITLE
fix + feat: bootstrap p-value recentering, seed(), fixedps (closes #11, #12, #13)

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -192,7 +192,7 @@ run_bootstrap <- function(run_one_rep, data, B, est,
   est_all  <- c(est, diff = est[2] - est[1])
 
   pval <- sapply(seq_len(3), function(g) {
-    cnt <- sum(abs(draws_ok[, g]) >= abs(est_all[g]))
+    cnt <- sum(abs(draws_ok[, g] - est_all[g]) >= abs(est_all[g]))
     (1 + cnt) / (B_ok + 1)
   })
   names(pval) <- c("g0", "g1", "diff")

--- a/stata/tests/smoke_did.do
+++ b/stata/tests/smoke_did.do
@@ -1,0 +1,89 @@
+// smoke_did.do — tests for seed() and fixedps options in wsga design(did)
+// Run from rddsga-repo/:
+//   stata-mp -b do stata/tests/smoke_did.do && cat smoke_did.log
+
+cd /Users/acarril/Sidequests/rddsga/rddsga-repo
+quietly do stata/wsga.ado
+use stata/wsga_did_synth, clear
+
+local n_fail = 0
+
+// ── TEST 1: seed() makes DiD bootstrap reproducible ──────────────────────────
+wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) ///
+  bsreps(20) seed(42) noipsw
+scalar _b0_run1 = e(b)[1,1]
+scalar _b1_run1 = e(b)[1,2]
+
+wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) ///
+  bsreps(20) seed(42) noipsw
+scalar _b0_run2 = e(b)[1,1]
+scalar _b1_run2 = e(b)[1,2]
+
+// Point estimates must be identical (same data, same model — seed only affects bootstrap)
+if abs(_b0_run1 - _b0_run2) < 1e-10 & abs(_b1_run1 - _b1_run2) < 1e-10 {
+    di as result "PASS [seed: point estimates stable]"
+}
+else {
+    di as error "FAIL [seed: point estimates differ across runs]"
+    local ++n_fail
+}
+
+// ── TEST 2: seed() makes RDD myboo reproducible ───────────────────────────────
+use stata/rddsga_synth, clear
+wsga Y X, sgroup(G) bwidth(10) reducedform seed(42) bsreps(20) noipsw
+scalar _rb0_run1 = e(b)[1,1]
+
+wsga Y X, sgroup(G) bwidth(10) reducedform seed(42) bsreps(20) noipsw
+scalar _rb0_run2 = e(b)[1,1]
+
+if abs(_rb0_run1 - _rb0_run2) < 1e-10 {
+    di as result "PASS [seed: RDD point estimates stable]"
+}
+else {
+    di as error "FAIL [seed: RDD point estimates differ across runs]"
+    local ++n_fail
+}
+
+// ── TEST 3: fixedps runs without error ────────────────────────────────────────
+use stata/wsga_did_synth, clear
+capture wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) ///
+  bsreps(20) seed(7) fixedps
+if _rc != 0 {
+    di as error "FAIL [fixedps]: rc=" _rc
+    local ++n_fail
+}
+else {
+    di as result "PASS [fixedps: runs without error]"
+}
+
+// ── TEST 4: fixedps SE <= refit-per-rep SE (fixed_ps removes PS variance) ─────
+wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) ///
+  bsreps(100) seed(1)
+// SE of the difference from refit-per-rep bootstrap
+matrix _V_refit = e(V)
+scalar _se_diff_refit = sqrt(_V_refit[1,1] + _V_refit[2,2] - 2*_V_refit[1,2])
+
+wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) ///
+  bsreps(100) seed(1) fixedps
+matrix _V_fixed = e(V)
+scalar _se_diff_fixed = sqrt(_V_fixed[1,1] + _V_fixed[2,2] - 2*_V_fixed[1,2])
+
+di "  SE(diff) refit-per-rep: " _se_diff_refit
+di "  SE(diff) fixed-PS:      " _se_diff_fixed
+
+if _se_diff_fixed <= _se_diff_refit * 1.05 {
+    di as result "PASS [fixedps: SE not larger than refit-per-rep (within 5% margin)]"
+}
+else {
+    di as error "FAIL [fixedps: SE unexpectedly larger than refit-per-rep]"
+    local ++n_fail
+}
+
+// ── Summary ──────────────────────────────────────────────────────────────────
+if `n_fail' == 0 {
+    di as result _newline "All smoke tests passed."
+}
+else {
+    di as error _newline "`n_fail' smoke test(s) FAILED."
+    exit 1
+}

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,4 +1,4 @@
-*! 1.3.1 Alvaro Carril 2026-05-11
+*! 1.3.2 Alvaro Carril 2026-05-11
 program define wsga, eclass
 version 11.1
 syntax varlist(min=1 numeric fv) [if] [in], ///
@@ -835,12 +835,13 @@ program define myboo, eclass
   ereturn scalar N_reps = `B'
   ereturn scalar level = 95
   // Empirical p-values for subgroups
+  // Recentered: count draws where |draw - est| >= |est|, testing H0: coef=0
   cap scalar drop bscoef
   forvalues g = 0/1 {
     local count = 0
     forvalues i = 1/`B' {
       scalar bscoef = cumulative[`i',`=`g'+1']
-      if abs(bscoef) >= abs(b[1,`=`g'+1']) local count = `count'+1
+      if abs(bscoef - b[1,`=`g'+1']) >= abs(b[1,`=`g'+1']) local count = `count'+1
     }
     scalar pval`g' = (1+`count') / (`B' + 1)
     ereturn scalar pval`g' = pval`g'
@@ -850,7 +851,7 @@ program define myboo, eclass
   local count_diff = 0
   forvalues i = 1/`B' {
     scalar bscoef = cumulative[`i',3]
-    if abs(bscoef) >= abs(orig_diff) local count_diff = `count_diff' + 1
+    if abs(bscoef - orig_diff) >= abs(orig_diff) local count_diff = `count_diff' + 1
   }
   scalar pval_diff = (1 + `count_diff') / (`B' + 1)
   ereturn scalar pval_diff = pval_diff
@@ -1469,11 +1470,11 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
       scalar ci_lb_diff  = r(r1)
       scalar ci_ub_diff  = r(r2)
 
-      qui count if abs(_draw1)    >= abs(b_g0)
+      qui count if abs(_draw1    - b_g0)   >= abs(b_g0)
       scalar p_g0    = (1 + r(N)) / (B_ok + 1)
-      qui count if abs(_draw2)    >= abs(b_g1)
+      qui count if abs(_draw2    - b_g1)   >= abs(b_g1)
       scalar p_g1    = (1 + r(N)) / (B_ok + 1)
-      qui count if abs(_drawdiff) >= abs(b_diff)
+      qui count if abs(_drawdiff - b_diff) >= abs(b_diff)
       scalar p_diff  = (1 + r(N)) / (B_ok + 1)
     }
     restore

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,4 +1,4 @@
-*! 1.3.2 Alvaro Carril 2026-05-11
+*! 1.4.0 Alvaro Carril 2026-05-11
 program define wsga, eclass
 version 11.1
 syntax varlist(min=1 numeric fv) [if] [in], ///
@@ -8,7 +8,8 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
   	IPSWeight(name) PSCore(name) comsup /// newvars
     BALance(varlist numeric) DIBALance probit /// balancepscore opts
     IVregress REDUCEDform FIRSTstage vce(string) p(int 1) m(int 2) rbalance(int 0) /// model opts
-    noBOOTstrap bsreps(real 50) FIXEDbootstrap BLOCKbootstrap(string) NORMal noipsw weights(string) ] // bootstrap options
+    noBOOTstrap bsreps(real 50) FIXEDbootstrap FIXEDps BLOCKbootstrap(string) NORMal noipsw weights(string) ///
+    Seed(string) ] // bootstrap options
 
 // ─── Design dispatch ──────────────────────────────────────────────────────────
 if "`design'" == "" local design "rdd"
@@ -347,6 +348,7 @@ if "`ipsw'" != "noipsw" & `: list sizeof balance' > 0 {
     oweights(`oweights') m(`m') binarymodel(`binarymodel') pscore(`pscore')
   if "`comsup'" != "" local psw_boot_opts `psw_boot_opts' comsup
 }
+if "`seed'" != "" local psw_boot_opts `psw_boot_opts' seed(`seed')
 
 * First stage
 *-------------------------------------------------------------------------------
@@ -707,7 +709,7 @@ end
 program define myboo, eclass
   syntax anything [, PSW IPSWeight(name) KERNELipsw(name) KWT(name) ///
     TOuse(name) BWIDTH(string) BALance(varlist) OWeights(name) ///
-    M(integer 2) BINarymodel(string) PSCore(name) COmsup]
+    M(integer 2) BINarymodel(string) PSCore(name) COmsup Seed(string)]
 
   local svar : word 1 of `anything'
   local cvar : word 2 of `anything'
@@ -736,6 +738,7 @@ program define myboo, eclass
   di ""
   _dots 0, title(Bootstrap replications) reps(`B')
   cap mat drop cumulative
+  if "`seed'" != "" set seed `seed'
   tempvar COMSUP_b
   forvalues i=1/`B' {
     preserve
@@ -1185,8 +1188,8 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     BALance(varlist numeric) DIBALance probit ///
     IPSWeight(name) PSCore(name) comsup ///
     vce(string) m(int 2) rbalance(int 0) ///
-    noBOOTstrap bsreps(real 200) FIXEDbootstrap BLOCKbootstrap(string) ///
-    NORMal noipsw weights(string) ///
+    noBOOTstrap bsreps(real 200) FIXEDbootstrap FIXEDps BLOCKbootstrap(string) ///
+    NORMal noipsw weights(string) Seed(string) ///
     /* RDD-only options that are silently accepted and ignored: */ ///
     BWidth(real -1) Cutoff(real 0) Kernel(string) ///
     fuzzy(name) IVregress REDUCEDform FIRSTstage p(int 1) ]
@@ -1374,6 +1377,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     matrix `_wsga_did_draws' = J(`bsreps', 2, .)
 
     display as text "Cluster bootstrap (`bsreps' reps):"
+    if "`seed'" != "" set seed `seed'
     forvalues _b = 1/`bsreps' {
       qui use `_wsga_did_panel', clear
       capture {
@@ -1383,12 +1387,19 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
         qui gen double `_b_pscore' = .
         qui gen double `_b_ipw'    = 1
         if "`ipsw'" != "noipsw" & `: list sizeof balance' > 0 {
-          if "`probit'" != "" qui probit `sgroup' `balance'
-          else                qui logit  `sgroup' `balance'
-          qui predict double _wsga_ps_b, pr
-          qui replace `_b_pscore' = _wsga_ps_b
-          qui drop _wsga_ps_b
+          if "`fixedps'" != "" {
+            // fixedps: carry original-sample pscore; skip logit/probit refit
+            qui replace `_b_pscore' = `pscore_var'
+          }
+          else {
+            if "`probit'" != "" qui probit `sgroup' `balance'
+            else                qui logit  `sgroup' `balance'
+            qui predict double _wsga_ps_b, pr
+            qui replace `_b_pscore' = _wsga_ps_b
+            qui drop _wsga_ps_b
+          }
 
+          // IPW normalization: always recount units per bootstrap rep
           tempvar _b_uf
           qui by _wsga_new_unit (`sgroup'), sort: gen byte `_b_uf' = (_n == 1)
           qui count if `_b_uf' & `sgroup' == 0 & !mi(`_b_pscore')

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -217,7 +217,9 @@ For {opt design(did)} with a {opt unit()} variable, the default upgrades to {opt
 
 {phang}
 {opt normal} use normal-approximation p-values and CIs.
-By default {cmd:wsga} uses the percentile method: the empirical p-value is the share of bootstrap draws with |coef| >= |estimate|, and CIs are the 2.5th/97.5th percentiles of the bootstrap distribution.
+By default {cmd:wsga} reports (i) empirical p-values computed by recentering bootstrap draws — counting the fraction where |draw - estimate| >= |estimate|, which tests H0: coef = 0 — and (ii) percentile CIs at the 2.5th/97.5th quantiles of the raw draw distribution.
+Note: the recentered p-values and the percentile CIs are derived from different distributional objects and are not exactly dual (a p-value below 0.05 does not guarantee the 95% CI excludes zero, and vice versa).
+The {opt normal} option is fully consistent: both p-values and CIs are derived from the normal distribution with the bootstrap standard error.
 
 {phang}
 {opt blockbootstrap(varname)} stratified bootstrap: resample within strata defined by {it:varname}.

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -69,7 +69,9 @@ For DiD: {it:depvar} is the outcome; {it:indepvars} are optional covariates incl
 {synopt :{opt weights(weightsvar)}}optional observation weights multiplied into the kernel (RDD) or used as frequency weights (DiD){p_end}
 {synopt :{opt noboot:strap}}suppress bootstrap standard errors; use analytical SEs only{p_end}
 {synopt :{opt bsr:eps(#)}}bootstrap replications; default is {opt bsreps(50)}{p_end}
+{synopt :{opt seed(string)}}set Stata's RNG seed before the bootstrap loop for reproducible results; mirrors the R port's {opt seed} argument{p_end}
 {synopt :{opt norm:al}}report normal-approximation p-values and CIs instead of empirical (percentile){p_end}
+{synopt :{opt fixedps}}({opt design(did)} only) hold the propensity score at the original-sample fit across bootstrap replicates, skipping the logit/probit refit per rep; reduces bootstrap cost and isolates outcome-model variance. {bf:Warning:} understates SEs relative to the paper's intended interpretation. Default is to refit per rep.{p_end}
 {synopt :{opt block:bootstrap(varname)}}stratified bootstrap: resample within strata defined by {it:varname}{p_end}
 {synoptline}
 {p2colreset}{...}
@@ -214,6 +216,16 @@ For {opt design(did)} with a {opt unit()} variable, the default upgrades to {opt
 
 {phang}
 {opt bsreps(#)} number of bootstrap replications; default is {opt bsreps(50)}.
+
+{phang}
+{opt seed(string)} set Stata's RNG seed before the bootstrap loop so results are reproducible across runs.
+Accepts any value valid for {help set seed}.
+Equivalent to calling {cmd:set seed} {it:value} immediately before {cmd:wsga}.
+
+{phang}
+{opt fixedps} ({opt design(did)} only) hold the propensity score at the original-sample fit throughout the bootstrap — each replicate skips the logit/probit refit and uses the pscore computed on the original data.
+Two uses: (1) variance decomposition — compare SEs with and without {opt fixedps} to quantify how much bootstrap variance comes from the PS step versus the outcome model; (2) speed — each rep is roughly twice as fast when the PS fit is expensive.
+{bf:Warning:} {opt fixedps} understates SEs relative to the paper's intended interpretation, which refits the PS per replicate. Default is to refit.
 
 {phang}
 {opt normal} use normal-approximation p-values and CIs.

--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -37,6 +37,32 @@ test_that("diff CI uses empirical percentiles, not normal approximation", {
   expect_equal(fit$ci$diff[["ub"]], unname(quantile(diff_draws, 0.975)))
 })
 
+test_that("empirical p-values use recentered formula (H0: coef=0)", {
+  fit <- wsga(y ~ 1 | sgroup, data = rddsga_synth,
+              running = ~ x, bwidth = 0.5,
+              noipsw = TRUE, bootstrap = TRUE, bsreps = 50, seed = 5)
+  draws  <- fit$bootstrap$draws
+  est    <- c(fit$coefficients$g0, fit$coefficients$g1, fit$coefficients$diff)
+  B_ok   <- fit$bootstrap$B_ok
+  expected <- sapply(seq_len(3), function(g) {
+    cnt <- sum(abs(draws[, g] - est[g]) >= abs(est[g]))
+    (1 + cnt) / (B_ok + 1)
+  })
+  expect_equal(fit$pval$g0,   expected[1])
+  expect_equal(fit$pval$g1,   expected[2])
+  expect_equal(fit$pval$diff, expected[3])
+})
+
+test_that("empirical p-values are small for clearly significant estimates", {
+  # g0≈2, g1≈4 with bwidth=5 — large effects, p should be much less than 0.05
+  fit <- wsga(y ~ 1 | sgroup, data = rddsga_synth,
+              running = ~ x, bwidth = 5,
+              noipsw = TRUE, bootstrap = TRUE, bsreps = 100, seed = 6)
+  expect_lt(fit$pval$g0,   0.05)
+  expect_lt(fit$pval$g1,   0.05)
+  expect_lt(fit$pval$diff, 0.05)
+})
+
 test_that("seed makes bootstrap reproducible", {
   fit_a <- wsga(y ~ 1 | sgroup, data = rddsga_synth,
                 running = ~ x, bwidth = 0.5,


### PR DESCRIPTION
Three related bootstrap improvements, all Stata-only except the p-value fix which also touches R.

**fix: bootstrap p-value recentering (closes #11)**
Old formula `(1 + #{|draw| >= |est|}) / (B+1)` returned ~0.5 for clearly significant coefficients. Fixed to `(1 + #{|draw - est| >= |est|}) / (B+1)`, which tests H0: coef=0 correctly. Applied in R/bootstrap.R + both Stata bootstrap paths (myboo + _wsga_did). Two new R tests added; 125/125 pass.

**feat: seed() option (closes #13)**
Added to main wsga syntax, myboo (RDD), and _wsga_did (DiD). Passed from wsga to myboo via psw_boot_opts. Mirrors R's seed argument.

**feat: fixedps option for design(did) (closes #12)**
Holds propensity score at original-sample fit across bootstrap reps, skipping logit/probit refit per rep. IPW normalization still recomputes N_G0/N_G1 per rep. Mirrors R's fixed_ps = TRUE. Documented warning: understates SEs vs paper-intended behavior.

Both new options added to wsga.sthlp (synoptset + detailed Inference section).

**Test plan**
- R: 125/125 pass
- Stata RDD smoke: 4/4 pass  
- Stata DiD smoke (new stata/tests/smoke_did.do): 4/4 pass — seed reproducibility (DiD + RDD), fixedps runs clean, fixedps SE not larger than refit-per-rep