### PR TITLE
feat(Stata): wsga rdd / wsga did subcommands (v1.5.0)

### DIFF
--- a/stata/rddsga.ado
+++ b/stata/rddsga.ado
@@ -1,6 +1,9 @@
-*! 1.2.0 Alvaro Carril 2026-05-09
-program define rddsga, eclass
-version 11.1
-display as text "{p}rddsga is deprecated and will be removed in a future major release. Use {cmd:wsga} instead.{p_end}"
-wsga `0'
+*! 1.3.0 Alvaro Carril 2026-05-11
+program define rddsga
+  version 11.1
+  di as error "rddsga is removed. Use {cmd:wsga rdd} instead."
+  di as text  "Note: the running variable is now a named option: {opt running(varname)}"
+  di as text  "Example: wsga rdd `depvar' [covars], sgroup(`sgroup') running(`assignvar') bwidth(...)"
+  di as text  "See {help wsga rdd} for full syntax."
+  exit 199
 end

--- a/stata/rddsga.sthlp
+++ b/stata/rddsga.sthlp
@@ -1,21 +1,26 @@
 {smcl}
-{* *! version 1.2.0 2026-05-09}{...}
+{* *! version 1.3.0 2026-05-11}{...}
 {title:Title}
 
 {pstd}
-{hi:rddsga} {hline 2} Deprecated alias for {cmd:wsga}
+{hi:rddsga} {hline 2} Removed alias (previously deprecated)
 
 
 {title:Description}
 
 {pstd}
-{cmd:rddsga} is the previous name of {cmd:wsga} (Weighted Subgroup Analysis). It is retained as a deprecated alias and will be removed in a future major release. New code should call {cmd:wsga} directly.
+{cmd:rddsga} has been removed. Use {cmd:wsga rdd} instead.
 
 {pstd}
-The deprecated alias forwards all arguments unchanged to {cmd:wsga} after printing a one-line deprecation notice. Estimation results are identical.
+Note: the running variable is now a named option rather than the second
+positional variable in the varlist:
+
+{phang2}
+{cmd:wsga rdd} {it:depvar} [{it:covariates}]{cmd:,}
+{opt sgroup(varname)} {opt running(varname)} {opt bwidth(#)} [...]
 
 
 {title:See also}
 
 {pstd}
-{help wsga}
+{help wsga}, {help wsga rdd}

--- a/stata/tests/smoke_did.do
+++ b/stata/tests/smoke_did.do
@@ -1,25 +1,23 @@
-// smoke_did.do — tests for seed() and fixedps options in wsga design(did)
+// smoke_did.do — tests for wsga did
 // Run from rddsga-repo/:
 //   stata-mp -b do stata/tests/smoke_did.do && cat smoke_did.log
 
-cd /Users/acarril/Sidequests/rddsga/rddsga-repo
 quietly do stata/wsga.ado
 use stata/wsga_did_synth, clear
 
 local n_fail = 0
 
 // ── TEST 1: seed() makes DiD bootstrap reproducible ──────────────────────────
-wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) ///
+wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
   bsreps(20) seed(42) noipsw
 scalar _b0_run1 = e(b)[1,1]
 scalar _b1_run1 = e(b)[1,2]
 
-wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) ///
+wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
   bsreps(20) seed(42) noipsw
 scalar _b0_run2 = e(b)[1,1]
 scalar _b1_run2 = e(b)[1,2]
 
-// Point estimates must be identical (same data, same model — seed only affects bootstrap)
 if abs(_b0_run1 - _b0_run2) < 1e-10 & abs(_b1_run1 - _b1_run2) < 1e-10 {
     di as result "PASS [seed: point estimates stable]"
 }
@@ -28,25 +26,8 @@ else {
     local ++n_fail
 }
 
-// ── TEST 2: seed() makes RDD myboo reproducible ───────────────────────────────
-use stata/rddsga_synth, clear
-wsga Y X, sgroup(G) bwidth(10) reducedform seed(42) bsreps(20) noipsw
-scalar _rb0_run1 = e(b)[1,1]
-
-wsga Y X, sgroup(G) bwidth(10) reducedform seed(42) bsreps(20) noipsw
-scalar _rb0_run2 = e(b)[1,1]
-
-if abs(_rb0_run1 - _rb0_run2) < 1e-10 {
-    di as result "PASS [seed: RDD point estimates stable]"
-}
-else {
-    di as error "FAIL [seed: RDD point estimates differ across runs]"
-    local ++n_fail
-}
-
-// ── TEST 3: fixedps runs without error ────────────────────────────────────────
-use stata/wsga_did_synth, clear
-capture wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) ///
+// ── TEST 2: fixedps runs without error ────────────────────────────────────────
+capture wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
   bsreps(20) seed(7) fixedps
 if _rc != 0 {
     di as error "FAIL [fixedps]: rc=" _rc
@@ -56,14 +37,13 @@ else {
     di as result "PASS [fixedps: runs without error]"
 }
 
-// ── TEST 4: fixedps SE <= refit-per-rep SE (fixed_ps removes PS variance) ─────
-wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) ///
+// ── TEST 3: fixedps SE <= refit-per-rep SE ────────────────────────────────────
+wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
   bsreps(100) seed(1)
-// SE of the difference from refit-per-rep bootstrap
 matrix _V_refit = e(V)
 scalar _se_diff_refit = sqrt(_V_refit[1,1] + _V_refit[2,2] - 2*_V_refit[1,2])
 
-wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) ///
+wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
   bsreps(100) seed(1) fixedps
 matrix _V_fixed = e(V)
 scalar _se_diff_fixed = sqrt(_V_fixed[1,1] + _V_fixed[2,2] - 2*_V_fixed[1,2])
@@ -79,7 +59,16 @@ else {
     local ++n_fail
 }
 
-// ── Summary ──────────────────────────────────────────────────────────────────
+// ── TEST 4: nobootstrap returns analytical SEs ────────────────────────────────
+capture wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) nobootstrap
+if _rc != 0 {
+    di as error "FAIL [nobootstrap]: rc=" _rc
+    local ++n_fail
+}
+else {
+    di as result "PASS [nobootstrap: runs without error]"
+}
+
 if `n_fail' == 0 {
     di as result _newline "All smoke tests passed."
 }

--- a/stata/tests/smoke_rdd.do
+++ b/stata/tests/smoke_rdd.do
@@ -1,11 +1,10 @@
-// smoke_rdd.do — basic RDD smoke test for wsga
+// smoke_rdd.do — basic RDD smoke test for wsga rdd
 // Run from rddsga-repo/:
 //   stata-mp -b do stata/tests/smoke_rdd.do && cat smoke_rdd.log
 //
 // Tests that all three kernel types run without error on rddsga_synth.dta
 // and that the uniform-kernel coefficient is in a plausible range.
 
-local ado_dir = subinstr(c(pwd), "", "", .)
 quietly do stata/wsga.ado
 
 use stata/rddsga_synth, clear
@@ -14,7 +13,7 @@ local n_fail = 0
 
 foreach kernel in "" "kernel(triangular)" "kernel(epanechnikov)" {
     local label = cond("`kernel'" == "", "uniform", "`kernel'")
-    capture wsga Y X, sgroup(G) bwidth(10) reducedform nobootstrap noipsw `kernel'
+    capture wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform nobootstrap noipsw `kernel'
     if _rc != 0 {
         di as error "FAIL [`label']: rc=" _rc
         local ++n_fail
@@ -25,7 +24,7 @@ foreach kernel in "" "kernel(triangular)" "kernel(epanechnikov)" {
 }
 
 // Sanity-check: G=0 coefficient should be non-missing and finite
-wsga Y X, sgroup(G) bwidth(10) reducedform nobootstrap noipsw
+wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform nobootstrap noipsw
 scalar _b0 = e(b)[1,1]
 if mi(_b0) {
     di as error "FAIL [coef check]: e(b)[1,1] is missing"
@@ -33,6 +32,19 @@ if mi(_b0) {
 }
 else {
     di as result "PASS [coef check]: G=0 coef = " _b0
+}
+
+// Seed makes bootstrap reproducible
+wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform bsreps(20) seed(42) noipsw
+scalar _rb0_run1 = e(b)[1,1]
+wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform bsreps(20) seed(42) noipsw
+scalar _rb0_run2 = e(b)[1,1]
+if abs(_rb0_run1 - _rb0_run2) < 1e-10 {
+    di as result "PASS [seed: RDD point estimates stable]"
+}
+else {
+    di as error "FAIL [seed: RDD point estimates differ across runs]"
+    local ++n_fail
 }
 
 if `n_fail' == 0 {

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,44 +1,42 @@
-*! 1.4.0 Alvaro Carril 2026-05-11
-program define wsga, eclass
+*! 1.5.0 Alvaro Carril 2026-05-11
+
+// ── Dispatcher ────────────────────────────────────────────────────────────────
+program define wsga
+  version 11.1
+  gettoken sub rest : 0, parse(" ")
+  local sub = strlower("`sub'")
+  if "`sub'" == "rdd" {
+    _wsga_rdd `rest'
+  }
+  else if "`sub'" == "did" {
+    _wsga_did `rest'
+  }
+  else {
+    di as error `"wsga: unknown subcommand "`sub'". Valid subcommands: rdd, did."'
+    di as text "Type {help wsga} for details."
+    exit 198
+  }
+end
+
+// ── RDD implementation ────────────────────────────────────────────────────────
+program define _wsga_rdd, eclass
 version 11.1
 syntax varlist(min=1 numeric fv) [if] [in], ///
-  SGroup(name) [ DESign(string) /// design switch: rdd (default) or did
-    BWidth(real -1) fuzzy(name) Cutoff(real 0) Kernel(string) /// RDD-specific
-    UNIt(varname) TIMe(varname) TReat(varname) POST_value(string) /// DiD-specific
-  	IPSWeight(name) PSCore(name) comsup /// newvars
-    BALance(varlist numeric) DIBALance probit /// balancepscore opts
-    IVregress REDUCEDform FIRSTstage vce(string) p(int 1) m(int 2) rbalance(int 0) /// model opts
-    noBOOTstrap bsreps(real 50) FIXEDbootstrap FIXEDps BLOCKbootstrap(string) NORMal noipsw weights(string) ///
-    Seed(string) ] // bootstrap options
+  SGroup(name) RUnning(varname) ///
+  [ BWidth(real -1) Cutoff(real 0) Kernel(string) fuzzy(name) ///
+    IPSWeight(name) PSCore(name) comsup ///
+    BALance(varlist numeric) DIBALance probit ///
+    IVregress REDUCEDform FIRSTstage vce(string) p(int 1) m(int 2) rbalance(int 0) ///
+    noBOOTstrap bsreps(real 200) FIXEDbootstrap FIXEDps BLOCKbootstrap(string) NORMal noipsw weights(string) ///
+    Seed(string) ]
 
-// ─── Design dispatch ──────────────────────────────────────────────────────────
-if "`design'" == "" local design "rdd"
-if "`design'" != "rdd" & "`design'" != "did" {
-  di as error "design() must be either 'rdd' or 'did' (got `design')."
-  exit 198
-}
-if "`design'" == "did" {
-  // Validate DiD-required options
-  if "`unit'" == "" | "`time'" == "" | "`treat'" == "" {
-    di as error "design(did) requires options unit(), time(), and treat()."
-    exit 198
-  }
-  if "`ivregress'" != "" | "`firststage'" != "" {
-    di as error ///
-"Fuzzy DiD is not currently supported. The paper's DiD identification (Carril et al., {it:Subgroup effect identification in DiD designs}) covers sharp DiD only. If you have imperfect compliance with treatment in a panel setting, consider this design out of scope."
-    exit 198
-  }
-  _wsga_did `0'
-  exit
-}
-// design == "rdd" from here: require bwidth and at least 2 variables in varlist
+// ─── Validate required options ────────────────────────────────────────────────
 if `bwidth' < 0 {
-  di as error "bwidth() is required (positive) when design(rdd) (default)."
+  di as error "bwidth() is required and must be positive."
   exit 198
 }
-local n_varlist : word count `varlist'
-if `n_varlist' < 2 {
-  di as error "design(rdd) requires both an outcome variable and an assignment variable in the varlist."
+if ("`ivregress'" != "" | "`firststage'" != "") & "`fuzzy'" == "" {
+  di as error "fuzzy() must be specified with ivregress or firststage."
   exit 198
 }
 // ──────────────────────────────────────────────────────────────────────────────
@@ -47,19 +45,11 @@ if `n_varlist' < 2 {
 * Check inputs
 *-------------------------------------------------------------------------------
 
-// Check that depvar and assignvar are not factor variables
-local fvops = "`s(fvops)'" == "true" | _caller() >= 11 
-if `fvops' { 
-  local vv: di "version " ///me
-  string(max(11,_caller())) ", missing: " 
+// Check that depvar is not a factor variable
+local fvops = "`s(fvops)'" == "true" | _caller() >= 11
+if `fvops' {
   gettoken first rest : varlist
-  gettoken second rest : rest
   _fv_check_depvar `first'
-  capture _fv_check_depvar `second'
-  if _rc!=0 {
-    di as error "assignvar {bf:`second'} may not be a factor variable"
-    exit 198
-  }
 }
 
 
@@ -132,12 +122,11 @@ marksample touse, novarlist
 // Extract outcome variable
 local depvar : word 1 of `varlist'
 
-// Extract assignment variable
-local assignvar :	word 2 of `varlist'
+// Running variable (from named option)
+local assignvar `running'
 
 // Define covariates list
 local covariates : list varlist - depvar
-local covariates : list covariates - assignvar
 
 // Add c. stub to continuous covariates in balance for factor interactions
 foreach var in `balance' {
@@ -265,7 +254,7 @@ scalar unw_N_G0 = `N_G0'
 if `: list sizeof balance'!=0 {
 
 // Compute balanace matrix 
-balancematrix, matname(unw)  ///
+_wsga_rdd_balancematrix, matname(unw)  ///
  weights(`oweights') assignvar(`assignvar') touse(`touse') bwidth(`bwidth') balance(`balance') m(`m') ///
   sgroup(`sgroup') sgroup0(`sgroup0') n_balance(`n_balance') rbalance(`rbalance')
   
@@ -294,7 +283,7 @@ if "`ipsw'" != "noipsw" {
 *-------------------------------------------------------------------------------
 // Compute balanace matrix 
 
-balancematrix, matname(ipsw)  ///
+_wsga_rdd_balancematrix, matname(ipsw)  ///
   psw ipsweight(`ipsweight') weights(`oweights') touse(`touse') assignvar(`assignvar') bwidth(`bwidth') balance(`balance') m(`m') ///
   pscore(`pscore') comsup nocomsup(`NOCOMSUP') binarymodel(`binarymodel') ///
 	sgroup(`sgroup') sgroup0(`sgroup0') n_balance(`n_balance')  rbalance(`rbalance') 
@@ -367,9 +356,9 @@ ereturn local blockbootstrap `blockbootstrap'
 }
     
   // Compute bootstrapped variance-covariance matrix and post results
-  if "`bootstrap'" != "nobootstrap" myboo `sgroup' _cutoff `bsreps', `psw_boot_opts'
+  if "`bootstrap'" != "nobootstrap" _wsga_rdd_myboo `sgroup' _cutoff `bsreps', `psw_boot_opts'
   // If no bootstrap, trim b and V to show only RD estimates
-  else epost `sgroup' _cutoff 
+  else _wsga_rdd_epost `sgroup' _cutoff 
 }
 
 * Reduced form
@@ -402,9 +391,9 @@ ereturn local blockbootstrap `blockbootstrap'
 }
 
   // Compute bootstrapped variance-covariance matrix and post results
-  if "`bootstrap'" != "nobootstrap" myboo `sgroup' _cutoff `bsreps', `psw_boot_opts'
+  if "`bootstrap'" != "nobootstrap" _wsga_rdd_myboo `sgroup' _cutoff `bsreps', `psw_boot_opts'
   // If no bootstrap, trim b and V to show only RD estimates
-  else epost `sgroup' _cutoff 
+  else _wsga_rdd_epost `sgroup' _cutoff 
 }
 
 * Instrumental variables
@@ -455,10 +444,10 @@ ereturn local cmdline `RFline'
     }
 
   // Compute bootstrapped variance-covariance matrix and post results
-  if "`bootstrap'" != "nobootstrap" myboo `sgroup' `fuzzy' `bsreps', `psw_boot_opts'
+  if "`bootstrap'" != "nobootstrap" _wsga_rdd_myboo `sgroup' `fuzzy' `bsreps', `psw_boot_opts'
 
   // If no bootstrap, trim b and V to show only RD estimates
-  else epost `sgroup' `fuzzy'
+  else _wsga_rdd_epost `sgroup' `fuzzy'
 *  mat cumulative = e(cumulative)
 *  ereturn matrix cumulative = cumulative
 
@@ -671,7 +660,7 @@ end
 *-------------------------------------------------------------------------------
 * epost: post matrices in e(b) and e(V); leave other ereturn results unchanged
 *-------------------------------------------------------------------------------
-program epost, eclass
+program _wsga_rdd_epost, eclass
   // Store results: scalars
   local scalars: e(scalars)
   foreach scalar of local scalars {
@@ -706,7 +695,7 @@ end
 *-------------------------------------------------------------------------------
 * myboo: compute bootstrapped variance-covariance matrix & adjust ereturn results
 *-------------------------------------------------------------------------------
-program define myboo, eclass
+program define _wsga_rdd_myboo, eclass
   syntax anything [, PSW IPSWeight(name) KERNELipsw(name) KWT(name) ///
     TOuse(name) BWIDTH(string) BALance(varlist) OWeights(name) ///
     M(integer 2) BINarymodel(string) PSCore(name) COmsup Seed(string)]
@@ -888,7 +877,7 @@ end
 *-------------------------------------------------------------------------------
 * nlcompost: modify b matrix after nlcom
 *-------------------------------------------------------------------------------
-program nlcompost, eclass
+program _wsga_rdd_nlcompost, eclass
   matrix b = e(b)
   matrix colnames b = Difference 
   ereturn repost b = b, rename // renames V matrix as well
@@ -897,7 +886,7 @@ end
 *-------------------------------------------------------------------------------
 * nlcomhack: hack b and V matrices to inlude nlcom results
 *-------------------------------------------------------------------------------
-program nlcomhack, eclass
+program _wsga_rdd_nlcomhack, eclass
   tempname b V nlcom_V
   matrix `b' = e(b)
   matrix `V' = e(V)
@@ -911,9 +900,9 @@ end
 
 
 *-------------------------------------------------------------------------------
-* balancematrix: compute balance table matrices and other statistics
+* _wsga_rdd_balancematrix: compute balance table matrices and other statistics
 *-------------------------------------------------------------------------------
-program define balancematrix, eclass
+program define _wsga_rdd_balancematrix, eclass
 syntax, matname(string) /// important inputs, differ by call
   touse(name)  weights(string) bwidth(string) balance(varlist) m(int) /// unchanging inputs
   [psw ipsweight(name)  pscore(name) comsup nocomsup(name) binarymodel(string)] /// only needed for PSW balance
@@ -1184,15 +1173,12 @@ program define _wsga_did, eclass
 version 11.1
 syntax varlist(min=1 numeric fv) [if] [in], ///
   SGroup(name) UNIt(varname) TIMe(varname) TReat(varname) ///
-  [ DESign(string) POST_value(string) ///
+  [ POST_value(string) ///
     BALance(varlist numeric) DIBALance probit ///
     IPSWeight(name) PSCore(name) comsup ///
-    vce(string) m(int 2) rbalance(int 0) ///
+    vce(string) m(int 2) ///
     noBOOTstrap bsreps(real 200) FIXEDbootstrap FIXEDps BLOCKbootstrap(string) ///
-    NORMal noipsw weights(string) Seed(string) ///
-    /* RDD-only options that are silently accepted and ignored: */ ///
-    BWidth(real -1) Cutoff(real 0) Kernel(string) ///
-    fuzzy(name) IVregress REDUCEDform FIRSTstage p(int 1) ]
+    NORMal noipsw weights(string) Seed(string) ]
 
   // ── Sample mask
   marksample touse, novarlist
@@ -1643,8 +1629,8 @@ CHANGE LOG
 0.3
   - Standardize syntax to merge with original rddsga.ado
 0.2
-  - Implement balancematrix as separate subroutine
-  - Standardize balancematrix output
+  - Implement _wsga_rdd_balancematrix as separate subroutine
+  - Standardize _wsga_rdd_balancematrix output
 0.1
 	- First working version, independent of project
 	- Remove any LaTeX output
@@ -1654,7 +1640,7 @@ KNOWN ISSUES/BUGS:
   - Should we use pweights or iweights? iw don't work with ivregress.
 
 TODOS AND IDEAS:
-  - Create subroutine of matlist formatting for display of balancematrix output
+  - Create subroutine of matlist formatting for display of _wsga_rdd_balancematrix output
   - Implement matrix manipulation in Mata
   - Get rid of sgroup0 hack
   - Allow that groupvar is not necessarily an indicator variable

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -104,7 +104,7 @@ if "`dibalance'" != ""  & `: list sizeof varlist'<=2 & `: list sizeof balance'==
 
 
 // Issue warning if options bsreps and normal are specified along with nobootstrap
-if "`bootstrap'" == "nobootstrap" & (`bsreps' != 50 | "`normal'" != "") {
+if "`bootstrap'" == "nobootstrap" & (`bsreps' != 200 | "`normal'" != "") {
   di as text "Warning: options " as result "bsreps" as text " and " as result "normal" ///
     as text " are irrelevant if " as result "nobootstrap" as text " is specified"
 }
@@ -188,7 +188,7 @@ local rbalance=0 // mean in cutoff
 *tempvar cutoffvar
 *gen _cutoff = (`assignvar'>`cutoff')
 *lab var _cutoff "fuzzy"
-confirm new variable _cutoff
+cap drop _cutoff
 gen _cutoff = (`assignvar'>`cutoff')
 
 // Compute spline options
@@ -872,30 +872,6 @@ program define _wsga_rdd_myboo, eclass
   ereturn local vcetype "Bootstrap"
   ereturn local vce "bootstrap"
   ereturn local prefix "bootstrap"
-end
-
-*-------------------------------------------------------------------------------
-* nlcompost: modify b matrix after nlcom
-*-------------------------------------------------------------------------------
-program _wsga_rdd_nlcompost, eclass
-  matrix b = e(b)
-  matrix colnames b = Difference 
-  ereturn repost b = b, rename // renames V matrix as well
-end
-
-*-------------------------------------------------------------------------------
-* nlcomhack: hack b and V matrices to inlude nlcom results
-*-------------------------------------------------------------------------------
-program _wsga_rdd_nlcomhack, eclass
-  tempname b V nlcom_V
-  matrix `b' = e(b)
-  matrix `V' = e(V)
-  local i = colnumb(`b', "_nl_1")
-  qui nlcom _b[1.`1'#1.`2'] - _b[0.`1'#1.`2']
-  matrix `nlcom_V' = r(V) // for some reason this is necessary
-  matrix `b'[1,`i'] = r(b)
-  matrix `V'[`i',`i'] = `nlcom_V'[1,1] // ...and this
-  ereturn repost b = `b' V = `V'
 end
 
 

--- a/stata/wsga.pkg
+++ b/stata/wsga.pkg
@@ -3,15 +3,15 @@ d 'WSGA': Weighted subgroup analysis
 d
 d  wsga conducts weighted subgroup analysis for research designs that
 d  require control variables for identification. It supports regression
-d  discontinuity (RD) designs (sharp and fuzzy) and sharp 2-period
-d  difference-in-differences (DiD). Observations in each
-d  subgroup are weighted by the inverse of their conditional probabilities
-d  to belong to that subgroup, given a set of moderators. Analyzing the
-d  differential treatment effect in the reweighted sample helps isolate the
-d  difference due to the subgroup characteristic of interest from other
-d  observable dimensions.
+d  discontinuity (RD) designs (sharp and fuzzy) via {cmd:wsga rdd} and
+d  sharp 2-period difference-in-differences (DiD) via {cmd:wsga did}.
+d  Observations in each subgroup are weighted by the inverse of their
+d  conditional probabilities to belong to that subgroup, given a set of
+d  moderators. Analyzing the differential treatment effect in the
+d  reweighted sample helps isolate the difference due to the subgroup
+d  characteristic of interest from other observable dimensions.
 d
-d  This package also installs the deprecated rddsga command (alias for wsga).
+d  This package also installs the deprecated rddsga command (stub).
 d
 d KW: Weighted subgroup analysis
 d KW: WSGA
@@ -23,7 +23,7 @@ d KW: Inverse probability weighting
 d
 d Requires: Stata version 11
 d
-d Distribution-Date: 20260509
+d Distribution-Date: 20260511
 d
 d Authors: Alvaro Carril
 d          Andre Cazor, PUC Chile
@@ -35,6 +35,8 @@ d Support: report issues at https://github.com/acarril/wsga/issues
 d
 F wsga.ado
 F wsga.sthlp
+F wsga_rdd.sthlp
+F wsga_did.sthlp
 F rddsga.ado
 F rddsga.sthlp
 f rddsga_synth.dta

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -1,357 +1,41 @@
 {smcl}
-{* *! version 1.3.0 2026-05-11}{...}
+{* *! version 1.5.0 2026-05-11}{...}
 {title:Title}
 
 {pstd}
-{hi:wsga} {hline 2} Weighted subgroup analysis (regression discontinuity and difference-in-differences)
+{hi:wsga} {hline 2} Weighted Subgroup Analysis
 
 
-{title:Syntax}
-
-{pstd}
-{ul:Regression discontinuity (RD) design} (default):
-
-{p 8 16 2}
-{cmd:wsga} {depvar} {it:assignvar} [{indepvars}] {ifin}
-{cmd:,} {opt sg:roup(varname)} {opt bw:idth(real)} [{it:rdd_options} {it:common_options}]
-{p_end}
-
-{pstd}
-{ul:Difference-in-differences (DiD) design}:
-
-{p 8 16 2}
-{cmd:wsga} {depvar} [{indepvars}] {ifin}
-{cmd:,} {opt sg:roup(varname)} {opt des:ign(did)} {opt un:it(varname)} {opt ti:me(varname)} {opt tr:eat(varname)} [{it:did_options} {it:common_options}]
-{p_end}
-
-{phang}
-For RD: {it:depvar} is the outcome; {it:assignvar} is the running variable with a known cutoff; {it:indepvars} are optional control/balance variables.{p_end}
-{phang}
-For DiD: {it:depvar} is the outcome; {it:indepvars} are optional covariates included in the outcome regression and used in the propensity score model.{p_end}
-
-{synoptset 26 tabbed}{...}
-{synopthdr}
-{synoptline}
-{syntab :Design (required)}
-{p2coldent:* {opth sg:roup(varname)}}binary (0/1) subgroup indicator variable{p_end}
-{synopt :{opt des:ign(string)}}{opt rdd} (default) or {opt did}; selects the estimation pipeline{p_end}
-
-{syntab :RDD-specific options}
-{p2coldent:* {opt bw:idth(real)}}symmetric bandwidth around the cutoff; required for {opt design(rdd)}{p_end}
-{synopt :{opth f:uzzy(varname)}}actual treatment receipt for fuzzy RD; if omitted, sharp RD is assumed{p_end}
-{synopt :{opt c:utoff(real)}}cutoff value in {it:assignvar}; default is {opt cutoff(0)}{p_end}
-{synopt :{opt k:ernel(kernelfn)}}kernel function: {opt uniform} (default), {opt triangular}, or {opt epanechnikov}{p_end}
-{synopt :{opt p:(int)}}polynomial order; default is {opt p(1)} (local linear){p_end}
-{synopt :{opt first:stage}}estimate the first stage (discontinuity in treatment probability){p_end}
-{synopt :{opt reduced:form}}estimate the reduced form RD effect{p_end}
-{synopt :{opt iv:regress}}estimate the treatment effect via 2SLS; requires {opt fuzzy(varname)}{p_end}
-{synopt :{opt fixed:bootstrap}}for fuzzy RD: bootstrap the reduced form only and divide by the fixed first-stage estimate{p_end}
-
-{syntab :DiD-specific options}
-{p2coldent:* {opt un:it(varname)}}panel unit identifier; required for {opt design(did)}{p_end}
-{p2coldent:* {opt ti:me(varname)}}time variable (must have exactly 2 unique values); required for {opt design(did)}{p_end}
-{p2coldent:* {opt tr:eat(varname)}}binary treatment indicator (unit-constant); required for {opt design(did)}{p_end}
-{synopt :{opt post:_value(string)}}value of {opt time()} denoting the post period; default is the larger of the two values{p_end}
-
-{syntab :Balance and weighting}
-{p2coldent:+ {opth bal:ance(varlist)}}variables entering the propensity score model; default is {it:indepvars}{p_end}
-{synopt :{opt probit}}estimate propensity score with {manhelp probit R:probit}; default is {manhelp logit R:logit}{p_end}
-{synopt :{opt com:sup}}restrict sample to common propensity score support{p_end}
-{synopt :{opt m:(int)}}weighting mode: {opt m(2)} (default) balances both subgroups toward the pooled distribution; {opt m(1)} weights G=1 toward G=0; {opt m(0)} weights G=0 toward G=1{p_end}
-{synopt :{opt rbal:ance(int)}}conditional mean method for RD balance tables: {opt rbalance(0)} (default) extrapolates to the cutoff; {opt rbalance(1)} uses the within-bandwidth mean{p_end}
-{synopt :{opt noipsw}}skip IPW entirely; subgroup estimates are computed without reweighting{p_end}
-{synopt :{opt dibal:ance}}display unweighted and IPW-weighted balance tables{p_end}
-{synopt :{opth ipsw:eight(newvar)}}save IPW weights to a new variable{p_end}
-{synopt :{opth psc:ore(newvar)}}save propensity scores to a new variable{p_end}
-
-{syntab :Inference}
-{synopt :{opth vce(vcetype)}}analytical variance estimator; default is {opt robust}; see {help vce_option}{p_end}
-{synopt :{opt weights(weightsvar)}}optional observation weights multiplied into the kernel (RDD) or used as frequency weights (DiD){p_end}
-{synopt :{opt noboot:strap}}suppress bootstrap standard errors; use analytical SEs only{p_end}
-{synopt :{opt bsr:eps(#)}}bootstrap replications; default is {opt bsreps(50)}{p_end}
-{synopt :{opt seed(string)}}set Stata's RNG seed before the bootstrap loop for reproducible results; mirrors the R port's {opt seed} argument{p_end}
-{synopt :{opt norm:al}}report normal-approximation p-values and CIs instead of empirical (percentile){p_end}
-{synopt :{opt fixedps}}({opt design(did)} only) hold the propensity score at the original-sample fit across bootstrap replicates, skipping the logit/probit refit per rep; reduces bootstrap cost and isolates outcome-model variance. {bf:Warning:} understates SEs relative to the paper's intended interpretation. Default is to refit per rep.{p_end}
-{synopt :{opt block:bootstrap(varname)}}stratified bootstrap: resample within strata defined by {it:varname}{p_end}
-{synoptline}
-{p2colreset}{...}
-{p 4 6 2}* Required options.{p_end}
-{p 4 6 2}+ Required if {it:indepvars} is empty and IPSW is used.{p_end}
-{p 4 6 2}{it:indepvars} may contain factor variables; see {help fvvarlist}.{p_end}
-
-
-{marker description}{...}
 {title:Description}
 
 {pstd}
-{cmd:wsga} conducts binary subgroup analysis using inverse propensity score weighting (IPSW) in two research designs.
+{cmd:wsga} implements weighted subgroup analysis for research designs that
+require control variables for identification. It uses inverse probability
+weighting (IPW) to balance observed moderators across subgroups, isolating
+the subgroup-attributable component of the treatment effect difference.
 
 {pstd}
-{ul:Regression discontinuity ({opt design(rdd)}, default).}
-Observations near the cutoff in each subgroup are reweighted so that the two subgroups have the same distribution of observed moderators at the cutoff.
-Any remaining difference in per-subgroup RD estimates can therefore be attributed to the subgroup characteristic rather than correlated moderators.
-{cmd:wsga} supports sharp RD ({opt reducedform}), the first stage of a fuzzy RD ({opt firststage}), and fuzzy RD via 2SLS ({opt ivregress}).
+{cmd:wsga} has two subcommands, one per research design:
+
+{phang2}
+{helpb wsga rdd} {hline 2} Regression discontinuity designs (sharp and fuzzy RD)
+
+{phang2}
+{helpb wsga did} {hline 2} Sharp 2-period difference-in-differences
+
+
+{title:Quick syntax}
 
 {pstd}
-{ul:Difference-in-differences ({opt design(did)}).}
-For a balanced 2-period panel, {cmd:wsga} runs a long-form two-way fixed effects (TWFE) regression with subgroup × post-treatment interactions.
-IPW reweighting ensures the two subgroups have the same distribution of observed moderators, so the difference in DiD estimates is attributable to the subgroup characteristic.
-Treatment must be binary, sharp, and unit-constant; fuzzy DiD is not supported.
-{opt design(did)} requires {opt unit()}, {opt time()}, and {opt treat()}.
+{cmd:wsga rdd} {it:depvar} [{it:covariates}]{cmd:,}
+{opt sgroup(varname)} {opt running(varname)} {opt bwidth(#)} [...]
 
 {pstd}
-{ul:Common features.}
-The propensity score for subgroup membership is estimated via {manhelp logit R:logit} (default) or {manhelp probit R:probit} on {it:indepvars}, or a separate set specified with {opt balance(varlist)}.
-Three weighting modes are available via {opt m()}: {opt m(2)} (default) targets the pooled distribution; {opt m(1)} and {opt m(0)} are ATT-style modes.
-Standard errors are bootstrap-based by default (empirical p-values and percentile CIs); the {opt normal} option switches to normal-approximation inference; {opt nobootstrap} uses the analytical sandwich estimator only.
-Balance tables report the standardized mean difference and joint F-statistic for both the unweighted and IPW-weighted samples.
-For {opt design(did)}, a second balance table restricted to treated units (D=1) is also reported.
+{cmd:wsga did} {it:depvar} [{it:covariates}]{cmd:,}
+{opt sgroup(varname)} {opt unit(varname)} {opt time(varname)} {opt treat(varname)} [...]
 
 
-{marker options}{...}
-{title:Options}
-
-{dlgtab:Design (required)}
-
-{phang}
-{opt sgroup(varname)} binary (0/1) subgroup indicator. Required for all designs.
-
-{phang}
-{opt design(string)} selects the estimation pipeline. {opt rdd} (default) runs the regression discontinuity path; {opt did} runs the 2-period difference-in-differences path.
-
-
-{dlgtab:RDD-specific options}
-
-{phang}
-{opt bwidth(real)} symmetric bandwidth around the cutoff. Required for {opt design(rdd)}.
-
-{phang}
-{opt fuzzy(varname)} actual treatment receipt indicator for fuzzy RD. Required when {opt ivregress} or {opt firststage} is specified.
-
-{phang}
-{opt cutoff(real)} cutoff value of {it:assignvar}; default is {opt cutoff(0)}.
-
-{phang}
-{opt kernel(kernelfn)} kernel for local-polynomial weighting: {opt uniform} (default), {opt triangular}, or {opt epanechnikov}.
-
-{phang}
-{opt p(int)} polynomial order; default is {opt p(1)} (local linear).
-
-{phang}
-{opt firststage} estimates the discontinuity in treatment probability (first stage of a fuzzy RD).
-
-{phang}
-{opt reducedform} estimates the reduced form RD effect on the outcome.
-
-{phang}
-{opt ivregress} estimates the treatment effect using 2SLS. Requires {opt fuzzy(varname)}.
-
-{phang}
-{opt fixedbootstrap} for fuzzy RD: bootstrap the reduced form only and divide by the fixed first-stage point estimate.
-
-
-{dlgtab:DiD-specific options}
-
-{phang}
-{opt unit(varname)} panel unit identifier. Required for {opt design(did)}.
-
-{phang}
-{opt time(varname)} time variable. Must have exactly two unique non-missing values. Required for {opt design(did)}.
-
-{phang}
-{opt treat(varname)} binary treatment indicator. Must be unit-constant (same value in both periods for every unit). Required for {opt design(did)}.
-
-{phang}
-{opt post_value(string)} value of {opt time()} that denotes the post period. Defaults to the larger of the two time values.
-
-
-{dlgtab:Balance and weighting}
-
-{phang}
-{opt balance(varlist)} variables entering the propensity score model.
-Defaults to {it:indepvars}. Useful when the balancing set differs from the control set.
-Required if {it:indepvars} is empty and IPSW is in use.
-
-{phang}
-{opt probit} use {manhelp probit R:probit} for the propensity score; default is {manhelp logit R:logit}.
-
-{phang}
-{opt comsup} restrict to common propensity score support: [{it:min}({it:pscore} | G=1), {it:max}({it:pscore} | G=1)].
-
-{phang}
-{opt m(int)} weighting mode.
-{opt m(2)} (default): weights both groups toward the pooled distribution.
-{opt m(1)}: weights group 1 toward the distribution of group 0.
-{opt m(0)}: weights group 0 toward the distribution of group 1.
-
-{phang}
-{opt rbalance(int)} method for computing conditional means in RD balance tables.
-{opt rbalance(0)} (default): extrapolates to the cutoff via local linear regression.
-{opt rbalance(1)}: uses within-bandwidth sample means.
-
-{phang}
-{opt noipsw} skip IPW entirely; subgroup estimates are computed without reweighting.
-
-{phang}
-{opt dibalance} display unweighted and IPW-weighted balance tables.
-
-{phang}
-{opt ipsweight(newvar)} save IPW weights to a new variable.
-
-{phang}
-{opt pscore(newvar)} save propensity scores to a new variable.
-
-
-{dlgtab:Inference}
-
-{phang}
-{opt vce(vcetype)} analytical variance estimator; default is {opt robust}. See {help vce_option}.
-For {opt design(did)} with a {opt unit()} variable, the default upgrades to {opt vce(cluster unit)}.
-
-{phang}
-{opt weights(weightsvar)} optional observation-level weights.
-
-{phang}
-{opt nobootstrap} suppress bootstrap variance estimation; use the sandwich estimator from {opt vce()} only.
-
-{phang}
-{opt bsreps(#)} number of bootstrap replications; default is {opt bsreps(50)}.
-
-{phang}
-{opt seed(string)} set Stata's RNG seed before the bootstrap loop so results are reproducible across runs.
-Accepts any value valid for {help set seed}.
-Equivalent to calling {cmd:set seed} {it:value} immediately before {cmd:wsga}.
-
-{phang}
-{opt fixedps} ({opt design(did)} only) hold the propensity score at the original-sample fit throughout the bootstrap — each replicate skips the logit/probit refit and uses the pscore computed on the original data.
-Two uses: (1) variance decomposition — compare SEs with and without {opt fixedps} to quantify how much bootstrap variance comes from the PS step versus the outcome model; (2) speed — each rep is roughly twice as fast when the PS fit is expensive.
-{bf:Warning:} {opt fixedps} understates SEs relative to the paper's intended interpretation, which refits the PS per replicate. Default is to refit.
-
-{phang}
-{opt normal} use normal-approximation p-values and CIs.
-By default {cmd:wsga} reports (i) empirical p-values computed by recentering bootstrap draws — counting the fraction where |draw - estimate| >= |estimate|, which tests H0: coef = 0 — and (ii) percentile CIs at the 2.5th/97.5th quantiles of the raw draw distribution.
-Note: the recentered p-values and the percentile CIs are derived from different distributional objects and are not exactly dual (a p-value below 0.05 does not guarantee the 95% CI excludes zero, and vice versa).
-The {opt normal} option is fully consistent: both p-values and CIs are derived from the normal distribution with the bootstrap standard error.
-
-{phang}
-{opt blockbootstrap(varname)} stratified bootstrap: resample within strata defined by {it:varname}.
-For {opt design(did)}, the bootstrap is a pairs-cluster bootstrap over units (Cameron-Gelbach-Miller); {opt blockbootstrap()} adds an additional stratification layer within that.
-
-
-{marker examples}{...}
-{title:Examples}
-
-{pstd}{ul:Regression discontinuity}
-
-{pstd}Load RD synthetic dataset{p_end}
-{phang2}{cmd:. use rddsga_synth}{p_end}
-
-{pstd}Assess covariate balance and display balance tables{p_end}
-{phang2}{cmd:. wsga Y Z, balance(X1) sgroup(G) bwidth(10) dibalance}{p_end}
-
-{pstd}Reduced form with IPW balancing on X1 and X2, 200 bootstrap replications{p_end}
-{phang2}{cmd:. wsga Y Z X1 X2, sgroup(G) bwidth(10) reducedform bsreps(200)}{p_end}
-
-{pstd}Fuzzy RD via 2SLS, saving IPW weights{p_end}
-{phang2}{cmd:. wsga Y Z X1 X2, sgroup(G) bwidth(6) ivregress fuzzy(T) ipsweight(wt)}{p_end}
-
-{pstd}Sharp RD without IPW{p_end}
-{phang2}{cmd:. wsga Y Z, sgroup(G) bwidth(10) reducedform noipsw nobootstrap}{p_end}
-
-{pstd}{ul:Difference-in-differences}
-
-{pstd}Load DiD synthetic panel dataset (500 units, 2 periods){p_end}
-{phang2}{cmd:. use wsga_did_synth}{p_end}
-
-{pstd}Unweighted DiD subgroup analysis (no IPW){p_end}
-{phang2}{cmd:. wsga y, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) noipsw}{p_end}
-
-{pstd}IPW-weighted DiD balancing on moderator m, display balance tables{p_end}
-{phang2}{cmd:. wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) dibalance}{p_end}
-
-{pstd}DiD with 200 cluster bootstrap replications{p_end}
-{phang2}{cmd:. wsga y m, sgroup(sgroup) design(did) unit(unit) time(time) treat(D) bsreps(200)}{p_end}
-
-
-{marker results}{...}
-{title:Stored results}
+{title:See also}
 
 {pstd}
-{cmd:wsga} stores the following in {cmd:e()}:
-
-{synoptset 28 tabbed}{...}
-{p2col 5 28 32 2: Scalars}{p_end}
-{synopt:{cmd:e(unw_N_G0)}}observations in subgroup 0 (unweighted){p_end}
-{synopt:{cmd:e(unw_N_G1)}}observations in subgroup 1 (unweighted){p_end}
-{synopt:{cmd:e(unw_Fstat)}}joint F-statistic (unweighted){p_end}
-{synopt:{cmd:e(unw_pvalue)}}F-statistic p-value (unweighted){p_end}
-{synopt:{cmd:e(unw_avgdiff)}}mean absolute standardized difference (unweighted){p_end}
-{synopt:{cmd:e(ipsw_N_G0)}}observations in subgroup 0 (IPW){p_end}
-{synopt:{cmd:e(ipsw_N_G1)}}observations in subgroup 1 (IPW){p_end}
-{synopt:{cmd:e(ipsw_Fstat)}}joint F-statistic (IPW){p_end}
-{synopt:{cmd:e(ipsw_pvalue)}}F-statistic p-value (IPW){p_end}
-{synopt:{cmd:e(ipsw_avgdiff)}}mean absolute standardized difference (IPW){p_end}
-{synopt:{cmd:e(N_reps)}}number of bootstrap replications{p_end}
-{synopt:{cmd:e(pval0)}}empirical p-value, subgroup 0{p_end}
-{synopt:{cmd:e(pval1)}}empirical p-value, subgroup 1{p_end}
-{synopt:{cmd:e(lb_g0)}}bootstrap CI lower bound, subgroup 0{p_end}
-{synopt:{cmd:e(ub_g0)}}bootstrap CI upper bound, subgroup 0{p_end}
-{synopt:{cmd:e(lb_g1)}}bootstrap CI lower bound, subgroup 1{p_end}
-{synopt:{cmd:e(ub_g1)}}bootstrap CI upper bound, subgroup 1{p_end}
-{synopt:{cmd:e(design)}}design in use: {cmd:rdd} or {cmd:did}{p_end}
-{synopt:{cmd:e(N_units)}}({opt design(did)} only) number of unique panel units{p_end}
-{synopt:{cmd:e(N_clusters)}}number of clusters used in a cluster bootstrap{p_end}
-
-{p2col 5 28 32 2: Matrices}{p_end}
-{synopt:{cmd:e(b)}}subgroup coefficient vector (G=0, G=1){p_end}
-{synopt:{cmd:e(V)}}variance-covariance matrix{p_end}
-{synopt:{cmd:e(unw)}}aggregate balance table (unweighted){p_end}
-{synopt:{cmd:e(ipsw)}}aggregate balance table (IPW){p_end}
-{synopt:{cmd:e(unw_treated)}}({opt design(did)} only) treated-only balance table (unweighted){p_end}
-{synopt:{cmd:e(ipsw_treated)}}({opt design(did)} only) treated-only balance table (IPW){p_end}
-{p2colreset}{...}
-
-{pstd}
-Additionally, all scalars and macros from the underlying estimation command ({opt reducedform}/{opt firststage}/{opt ivregress} for RDD; {help xtreg:xtreg, fe} for DiD) are stored in {cmd:e()}.
-See {help regress##results:Stored Results} and {help xtreg##results:xtreg Stored Results} for details.
-
-
-{marker authors}{...}
-{title:Authors}
-
-{pstd}
-Alvaro Carril (maintainer){break}
-acarril@princeton.edu
-
-{pstd}
-Andre Cazor{break}
-
-{pstd}
-Maria Paula Gerardino{break}
-Inter-American Development Bank{break}
-
-{pstd}
-Stephan Litschig{break}
-National Graduate Institute for Policy Studies{break}
-
-{pstd}
-Dina Pomeranz{break}
-University of Zurich{break}
-
-
-{marker disclaimer}{...}
-{title:Disclaimer}
-
-{pstd}
-This software is provided "as is", without warranty of any kind.
-Please report issues at {browse "https://github.com/acarril/wsga/issues"}.
-
-
-{marker references}{...}
-{title:References}
-
-{phang}
-Carril, Alvaro, Andre Cazor, Maria Paula Gerardino, Stephan Litschig, and Dina Pomeranz. "Weighted Subgroup Analysis in Regression Discontinuity Designs." Working paper.{p_end}
-
-{phang}
-Cameron, A. Colin, Jonah B. Gelbach, and Douglas L. Miller. "Bootstrap-Based Improvements for Inference with Clustered Errors." {it:Review of Economics and Statistics} 90(3): 414-427, 2008.{p_end}
+{help wsga rdd}, {help wsga did}

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -1,0 +1,77 @@
+{smcl}
+{* *! version 1.5.0 2026-05-11}{...}
+{title:Title}
+
+{pstd}
+{hi:wsga did} {hline 2} Weighted Subgroup Analysis for Difference-in-Differences Designs
+
+
+{title:Syntax}
+
+{p 8 16 2}
+{cmd:wsga did} {it:depvar} [{it:covariates}] {ifin}{cmd:,}
+  {opt sgroup(varname)}
+  {opt unit(varname)}
+  {opt time(varname)}
+  {opt treat(varname)}
+  [{it:options}]
+
+{synoptset 26 tabbed}{...}
+{synopthdr}
+{synoptline}
+{syntab:Required}
+{synopt:{opt sgroup(varname)}}binary (0/1) subgroup indicator (unit-constant){p_end}
+{synopt:{opt unit(varname)}}unit identifier (panel ID){p_end}
+{synopt:{opt time(varname)}}time variable; must have exactly 2 unique values{p_end}
+{synopt:{opt treat(varname)}}binary (0/1) treatment indicator (unit-constant){p_end}
+{syntab:DiD options}
+{synopt:{opt post_value(val)}}value of {it:time} denoting the post period; default max({it:time}){p_end}
+{syntab:IPW}
+{synopt:{opt balance(varlist)}}moderators for propensity score; defaults to covariates{p_end}
+{synopt:{opt noipsw}}skip IPW reweighting{p_end}
+{synopt:{opt m(#)}}weighting mode: 2 = both groups (default), 1 = G1→G0, 0 = G0→G1{p_end}
+{synopt:{opt probit}}use probit instead of logit for propensity score{p_end}
+{synopt:{opt comsup}}restrict to common propensity score support{p_end}
+{synopt:{opt dibalance}}display balance tables{p_end}
+{syntab:Inference}
+{synopt:{opt nobootstrap}}report analytical cluster-robust SEs only{p_end}
+{synopt:{opt bsreps(#)}}bootstrap replications; default 200{p_end}
+{synopt:{opt normal}}normal-approximation CIs from bootstrap SE{p_end}
+{synopt:{opt seed(#)}}RNG seed for reproducibility{p_end}
+{synopt:{opt fixedps}}hold propensity score fixed across bootstrap reps (diagnostic){p_end}
+{synopt:{opt blockbootstrap(varname)}}stratified block bootstrap{p_end}
+{synopt:{opt weights(varname)}}pre-existing observation weights{p_end}
+{synoptline}
+
+
+{title:Description}
+
+{pstd}
+{cmd:wsga did} estimates per-subgroup treatment effects and their difference
+in a sharp 2-period difference-in-differences design. The estimator is a
+long-form TWFE regression (unit + time fixed effects) fully interacted by
+subgroup. Inverse probability weighting (IPW) balances observed moderators
+across subgroups.
+
+{pstd}
+The cluster bootstrap resamples whole units with replacement and assigns fresh
+unit IDs per draw so fixed effects remain identified (Cameron–Gelbach–Miller).
+Clustering is always on {it:unit}.
+
+
+{title:Examples}
+
+{pstd}Unweighted DiD subgroup analysis:{p_end}
+{phang2}{cmd:. wsga did Y, sgroup(G) unit(id) time(t) treat(D) noipsw nobootstrap}{p_end}
+
+{pstd}IPW-weighted DiD:{p_end}
+{phang2}{cmd:. wsga did Y M, sgroup(G) unit(id) time(t) treat(D) nobootstrap}{p_end}
+
+{pstd}With cluster bootstrap:{p_end}
+{phang2}{cmd:. wsga did Y M, sgroup(G) unit(id) time(t) treat(D) bsreps(200) seed(1)}{p_end}
+
+
+{title:See also}
+
+{pstd}
+{help wsga}, {help wsga rdd}

--- a/stata/wsga_rdd.sthlp
+++ b/stata/wsga_rdd.sthlp
@@ -1,0 +1,81 @@
+{smcl}
+{* *! version 1.5.0 2026-05-11}{...}
+{title:Title}
+
+{pstd}
+{hi:wsga rdd} {hline 2} Weighted Subgroup Analysis for Regression Discontinuity Designs
+
+
+{title:Syntax}
+
+{p 8 16 2}
+{cmd:wsga rdd} {it:depvar} [{it:covariates}] {ifin}{cmd:,}
+  {opt sgroup(varname)}
+  {opt running(varname)}
+  {opt bwidth(#)}
+  [{it:options}]
+
+{synoptset 26 tabbed}{...}
+{synopthdr}
+{synoptline}
+{syntab:Required}
+{synopt:{opt sgroup(varname)}}binary (0/1) subgroup indicator{p_end}
+{synopt:{opt running(varname)}}running variable (centered at the cutoff internally){p_end}
+{synopt:{opt bwidth(#)}}half-bandwidth (positive){p_end}
+{syntab:RD model}
+{synopt:{opt cutoff(#)}}cutoff value; default 0{p_end}
+{synopt:{opt reducedform}}estimate reduced form (default){p_end}
+{synopt:{opt firststage}}estimate first stage of fuzzy RD{p_end}
+{synopt:{opt ivregress}}2SLS fuzzy RD{p_end}
+{synopt:{opt fuzzy(varname)}}treatment take-up variable (required with {opt ivregress}/{opt firststage}){p_end}
+{synopt:{opt p(#)}}polynomial order; default 1 (local linear){p_end}
+{synopt:{opt kernel(string)}}{opt uni}form (default), {opt tri}angular, or {opt epa}nechnikov{p_end}
+{syntab:IPW}
+{synopt:{opt balance(varlist)}}moderators for propensity score; defaults to covariates{p_end}
+{synopt:{opt noipsw}}skip IPW reweighting{p_end}
+{synopt:{opt m(#)}}weighting mode: 2 = both groups (default), 1 = G1→G0, 0 = G0→G1{p_end}
+{synopt:{opt probit}}use probit instead of logit for propensity score{p_end}
+{synopt:{opt comsup}}restrict to common propensity score support{p_end}
+{synopt:{opt dibalance}}display balance tables{p_end}
+{synopt:{opt rbalance(#)}}balance table means: 0 = at cutoff (default), 1 = in sample{p_end}
+{syntab:Inference}
+{synopt:{opt nobootstrap}}report analytical SEs only{p_end}
+{synopt:{opt bsreps(#)}}bootstrap replications; default 200{p_end}
+{synopt:{opt normal}}normal-approximation CIs from bootstrap SE{p_end}
+{synopt:{opt seed(#)}}RNG seed for reproducibility{p_end}
+{synopt:{opt fixedbootstrap}}fixed first-stage bootstrap for IV{p_end}
+{synopt:{opt fixedps}}hold propensity score fixed across bootstrap reps (diagnostic){p_end}
+{synopt:{opt blockbootstrap(varname)}}stratified block bootstrap{p_end}
+{synopt:{opt vce(vcetype)}}SE type; default robust{p_end}
+{synopt:{opt weights(varname)}}pre-existing observation weights{p_end}
+{synoptline}
+
+
+{title:Description}
+
+{pstd}
+{cmd:wsga rdd} estimates per-subgroup treatment effects and their difference
+in a sharp or fuzzy regression discontinuity (RD) design. Inverse probability
+weighting (IPW) balances observed moderators across subgroups, isolating the
+subgroup-attributable component of the effect difference.
+
+
+{title:Examples}
+
+{pstd}Sharp RD, no IPW:{p_end}
+{phang2}{cmd:. wsga rdd Y, sgroup(G) running(X) bwidth(0.5) noipsw nobootstrap}{p_end}
+
+{pstd}Sharp RD with IPW on moderator M:{p_end}
+{phang2}{cmd:. wsga rdd Y M, sgroup(G) running(X) bwidth(0.5) nobootstrap}{p_end}
+
+{pstd}With bootstrap inference:{p_end}
+{phang2}{cmd:. wsga rdd Y M, sgroup(G) running(X) bwidth(0.5) bsreps(200) seed(42)}{p_end}
+
+{pstd}Fuzzy RD via 2SLS:{p_end}
+{phang2}{cmd:. wsga rdd Y, sgroup(G) running(X) bwidth(0.5) ivregress fuzzy(D) nobootstrap}{p_end}
+
+
+{title:See also}
+
+{pstd}
+{help wsga}, {help wsga did}


### PR DESCRIPTION
Partial close of #21 — Stata half.

## What changed

Replaces `wsga design(rdd|did)` with a Stata-idiomatic subcommand interface: `wsga rdd ...` and `wsga did ...` (like `import excel` / `import delimited`).

**Architecture**
- `wsga.ado` now holds: thin dispatcher (`program define wsga`) + `_wsga_rdd` + `_wsga_did` + all helpers in one file — the standard Stata pattern for commands with subcommands
- All RDD private helpers renamed `_wsga_rdd_*` to avoid namespace pollution (`myboo` → `_wsga_rdd_myboo`, etc.)

**Breaking changes**
- `wsga design(rdd) depvar assignvar, ...` → `wsga rdd depvar, running(assignvar) ...` — running variable promoted from positional to named option
- `wsga design(did) depvar, unit() time() treat()` → `wsga did depvar, unit() time() treat()`
- `rddsga` removed with a migration error message (syntax is incompatible — running variable moved)

**Help files**
- `wsga.sthlp` — landing page listing both subcommands (like `help import`)
- `wsga_rdd.sthlp` — full RDD syntax and options
- `wsga_did.sthlp` — full DiD syntax and options

## Test plan

- [ ] `wsga rdd` smoke tests pass (3 kernels, coef sanity, seed reproducibility)
- [ ] `wsga did` smoke tests pass (seed, fixedps, nobootstrap)
- [ ] `help wsga` shows subcommand landing page
- [ ] `help wsga rdd` / `help wsga did` resolve correctly