### PR TITLE
wsga v1.0.0: subcommand interface, DiD split, unified versioning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 0.8.0
+Version: 1.0.0
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # wsga (R package) NEWS
 
-## wsga 0.8.0 (2026-05-11)
+## wsga 1.0.0 (2026-05-11)
 
 ### Breaking changes
 
@@ -37,7 +37,7 @@
 
 ## rddsga 0.3.0 → wsga 0.6.x (internal milestones)
 
-- Umbrella refactor: single `wsga()` entry point dispatching both RD and DiD paths (replaced by `wsga_rdd()` / `wsga_did()` in 0.8.0).
+- Umbrella refactor: single `wsga()` entry point dispatching both RD and DiD paths (replaced by `wsga_rdd()` / `wsga_did()` in 1.0.0).
 - S3 methods: `print`, `summary`, `coef`, `vcov`, `confint`, `nobs`.
 - `block_var` stratification for the bootstrap.
 - `seed` argument for reproducible bootstrap draws.


### PR DESCRIPTION
## Summary

- **R**: splits `wsga()` into `wsga_rdd()` / `wsga_did()` public entry points; fixes bootstrap p-value recentering (closes #11); doc improvements
- **Stata**: splits `wsga` into `wsga rdd` / `wsga did` subcommand interface; adds `seed()` and `fixedps` options (closes #12, #13); kernel macro fix (closes #14); DiD documentation (closes #15)
- **Versioning**: adopts unified `vX.Y.Z` scheme for both languages; bumps to `v1.0.0` — first release under the `wsga` identity (closes #16)

Old rddsga-era tags and GitHub releases have been deleted; `v1.0.0` is now the single Latest release.

## Test plan

- [ ] `devtools::check()` passes (0 errors / 0 warnings / 0 notes)
- [ ] `devtools::test()` passes
- [ ] Stata smoke tests: `stata-mp -b do stata/tests/smoke_rdd.do` and `stata/tests/smoke_did.do`
- [ ] `packageVersion("wsga")` returns `"1.0.0"`