### PR TITLE
bug(Stata/did): post clean e(b)/e(V) trimmed to G0_Z and G1_Z

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 1.0.0
+Version: 1.0.1
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # wsga (R package) NEWS
 
+## wsga 1.0.1 (2026-05-11)
+
+### Bug fixes
+
+- **Stata**: `wsga did` now calls `ereturn post` at the end of `_wsga_did`,
+  trimming `e(b)` and `e(V)` to the two treatment-effect columns (`G0_Z`,
+  `G1_Z`). Previously the full `xtreg, fe` result was left in `e()`, so
+  `e(b)` / `e(V)` were unreliable in downstream code. Bootstrap path now also
+  computes the covariance of the two coefficient draws so that `e(V)` is fully
+  bootstrap-derived when bootstrap is on (#24).
+- **Stata**: align `*!` version line with unified `1.0.x` versioning.
+
+---
+
 ## wsga 1.0.0 (2026-05-11)
 
 ### Breaking changes

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,4 +1,4 @@
-*! 1.5.0 Alvaro Carril 2026-05-11
+*! 1.0.1 Alvaro Carril 2026-05-11
 
 // ── Dispatcher ────────────────────────────────────────────────────────────────
 program define wsga
@@ -1287,6 +1287,8 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
   qui xtset `unit'
   local rhs `G0_Z' `G1_Z' `G0_post' `G1_post' `g0_covs' `g1_covs'
   xtreg `depvar' `rhs' [pw=`ipw_var'] if `touse' & `ipw_var' > 0, fe vce(cluster `unit')
+  tempvar _did_esample
+  gen byte `_did_esample' = e(sample)
 
   // ── Extract coefficients of interest
   scalar b_g0   = _b[`G0_Z']
@@ -1415,6 +1417,10 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     scalar se_g1   = r(sd)
     qui summarize _drawdiff
     scalar se_diff = r(sd)
+    qui correlate _draw1 _draw2, covariance
+    matrix _wsga_cov = r(C)
+    scalar cov_01 = _wsga_cov[1,2]
+    matrix drop _wsga_cov
     scalar t_g0   = b_g0   / se_g0
     scalar t_g1   = b_g1   / se_g1
     scalar t_diff = b_diff / se_diff
@@ -1560,12 +1566,55 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
       }
     }
   }
+
+  // ── Post clean e(b)/e(V) trimmed to the two treatment-effect columns.
+  // Analytic case: cov_01 comes from xtreg's VCV.
+  // Bootstrap case: cov_01 is overwritten above with the bootstrap covariance.
+  matrix _b_did = (b_g0, b_g1)
+  matrix colnames _b_did = G0_Z G1_Z
+  matrix _V_did = (se_g0^2, cov_01 \ cov_01, se_g1^2)
+  matrix rownames _V_did = G0_Z G1_Z
+  matrix colnames _V_did = G0_Z G1_Z
+  ereturn post _b_did _V_did, esample(`_did_esample')
+  ereturn local cmd    "wsga"
+  ereturn local subcmd "did"
+  ereturn local depvar "`depvar'"
+  ereturn scalar b_g0       = b_g0
+  ereturn scalar b_g1       = b_g1
+  ereturn scalar b_diff     = b_diff
+  ereturn scalar se_g0      = se_g0
+  ereturn scalar se_g1      = se_g1
+  ereturn scalar se_diff    = se_diff
+  ereturn scalar t_g0       = t_g0
+  ereturn scalar t_g1       = t_g1
+  ereturn scalar t_diff     = t_diff
+  ereturn scalar p_g0       = p_g0
+  ereturn scalar p_g1       = p_g1
+  ereturn scalar p_diff     = p_diff
+  ereturn scalar ci_lb_g0   = ci_lb_g0
+  ereturn scalar ci_ub_g0   = ci_ub_g0
+  ereturn scalar ci_lb_g1   = ci_lb_g1
+  ereturn scalar ci_ub_g1   = ci_ub_g1
+  ereturn scalar ci_lb_diff = ci_lb_diff
+  ereturn scalar ci_ub_diff = ci_ub_diff
+  ereturn scalar N_G0       = N_G0
+  ereturn scalar N_G1       = N_G1
+  ereturn scalar df         = df
+  if use_bootstrap {
+    ereturn scalar B_ok    = B_ok
+    ereturn scalar N_clust = N_clust
+  }
 end
 
 ********************************************************************************
 
 /*
 CHANGE LOG
+1.0.1
+  - bug(Stata/did): add ereturn post at end of _wsga_did to trim e(b)/e(V) to
+    G0_Z and G1_Z columns; bootstrap path now also computes covariance of the
+    two draws so V is fully bootstrap-derived when bootstrap is on
+  - chore: align Stata *! version with unified 1.0.x versioning
 1.3
   - Add design(did) path: sharp 2-period DiD-SGA via xtreg, fe with
     cluster-robust SEs (TWFE design matrix: subgroup-interacted unit FE

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -1,5 +1,6 @@
 {smcl}
-{* *! version 1.5.0 2026-05-11}{...}
+{* *! version 1.0.1 2026-05-11}{...}
+{viewerjumpto "Stored results" "wsga_did##results"}{...}
 {title:Title}
 
 {pstd}
@@ -69,6 +70,58 @@ Clustering is always on {it:unit}.
 
 {pstd}With cluster bootstrap:{p_end}
 {phang2}{cmd:. wsga did Y M, sgroup(G) unit(id) time(t) treat(D) bsreps(200) seed(1)}{p_end}
+
+
+{marker results}{...}
+{title:Stored results}
+
+{pstd}
+{cmd:wsga did} stores the following in {cmd:e()}:
+
+{synoptset 23 tabbed}{...}
+{p2col 5 23 26 2: Scalars}{p_end}
+{synopt:{cmd:e(b_g0)}}subgroup-0 treatment effect{p_end}
+{synopt:{cmd:e(b_g1)}}subgroup-1 treatment effect{p_end}
+{synopt:{cmd:e(b_diff)}}{cmd:e(b_g1)} minus {cmd:e(b_g0)}{p_end}
+{synopt:{cmd:e(se_g0)}}standard error for subgroup-0{p_end}
+{synopt:{cmd:e(se_g1)}}standard error for subgroup-1{p_end}
+{synopt:{cmd:e(se_diff)}}standard error for the difference{p_end}
+{synopt:{cmd:e(t_g0)}}t or z statistic for subgroup-0{p_end}
+{synopt:{cmd:e(t_g1)}}t or z statistic for subgroup-1{p_end}
+{synopt:{cmd:e(t_diff)}}t or z statistic for the difference{p_end}
+{synopt:{cmd:e(p_g0)}}p-value for subgroup-0{p_end}
+{synopt:{cmd:e(p_g1)}}p-value for subgroup-1{p_end}
+{synopt:{cmd:e(p_diff)}}p-value for the difference{p_end}
+{synopt:{cmd:e(ci_lb_g0)}}95% confidence interval lower bound, subgroup-0{p_end}
+{synopt:{cmd:e(ci_ub_g0)}}95% confidence interval upper bound, subgroup-0{p_end}
+{synopt:{cmd:e(ci_lb_g1)}}95% confidence interval lower bound, subgroup-1{p_end}
+{synopt:{cmd:e(ci_ub_g1)}}95% confidence interval upper bound, subgroup-1{p_end}
+{synopt:{cmd:e(ci_lb_diff)}}95% confidence interval lower bound, difference{p_end}
+{synopt:{cmd:e(ci_ub_diff)}}95% confidence interval upper bound, difference{p_end}
+{synopt:{cmd:e(N_G0)}}number of observations in subgroup 0{p_end}
+{synopt:{cmd:e(N_G1)}}number of observations in subgroup 1{p_end}
+{synopt:{cmd:e(df)}}degrees of freedom for analytical inference{p_end}
+{synopt:{cmd:e(B_ok)}}(bootstrap) number of successful replications{p_end}
+{synopt:{cmd:e(N_clust)}}(bootstrap) number of clusters{p_end}
+
+{p2col 5 23 26 2: Macros}{p_end}
+{synopt:{cmd:e(cmd)}}{cmd:wsga}{p_end}
+{synopt:{cmd:e(subcmd)}}{cmd:did}{p_end}
+{synopt:{cmd:e(depvar)}}name of dependent variable{p_end}
+
+{p2col 5 23 26 2: Matrices}{p_end}
+{synopt:{cmd:e(b)}}1{cmd:x}2 coefficient vector with columns named {cmd:G0_Z} and {cmd:G1_Z}{p_end}
+{synopt:{cmd:e(V)}}2{cmd:x}2 variance-covariance matrix; bootstrap-derived when bootstrap is on, analytical (cluster-robust) otherwise{p_end}
+
+{p2col 5 23 26 2: Functions}{p_end}
+{synopt:{cmd:e(sample)}}marks estimation sample{p_end}
+{p2colreset}{...}
+
+{pstd}
+Named column access works after estimation:{p_end}
+{phang2}{cmd:. matrix b = e(b)}{p_end}
+{phang2}{cmd:. scalar b_g0 = b[1,"G0_Z"]}{p_end}
+{phang2}{cmd:. scalar se_diff = sqrt(e(V)[1,1] + e(V)[2,2] - 2*e(V)[1,2])}{p_end}
 
 
 {title:See also}


### PR DESCRIPTION
Closes #24.

## Summary

- `_wsga_did` left xtreg's full `e(b)`/`e(V)` in `e()` on return. With covariates, positional access to `e(b)` is unreliable, and after the bootstrap path the last bootstrap rep's `xtreg` result was in `e()` instead of the original-sample one.
- Adds an `ereturn post` step at the end of `_wsga_did` (analogous to `_wsga_rdd_epost`) that posts a clean 1×2 `e(b)` and 2×2 `e(V)` with columns named `G0_Z` / `G1_Z`, plus all scalar results.
- In the bootstrap path, computes the covariance of the two coefficient draws via `correlate, covariance` so that `e(V)` is fully bootstrap-derived (diagonal entries are bootstrap variances; off-diagonal is bootstrap covariance).
- Aligns the Stata `*!` version to `1.0.1` (was `1.5.0`; unified versioning with R package and GH release).
- Bumps R `DESCRIPTION` and `NEWS.md` to `1.0.1`.
- Adds a `Stored results` section to `wsga_did.sthlp` in official Stata format.

## Test plan

- [x] `stata-mp -b do stata/tests/smoke_did.do` — all 4 existing smoke tests pass
- [x] Smoke test 3 verifies `sqrt(e(V)[1,1] + e(V)[2,2] - 2*e(V)[1,2])` recovers `se_diff` correctly from the new 2×2 `e(V)`
- [x] `e(b)[1,1]` / `e(b)[1,2]` / `e(b)[1,"G0_Z"]` / `e(b)[1,"G1_Z"]` all return correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)