### PR TITLE
fix(Stata/rdd) + breaking: mode-aware e-returns, unified naming (#32)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 1.0.3
+Version: 1.1.0
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,39 @@
 # wsga (R package) NEWS
 
+## wsga 1.1.0 (2026-05-25)
+
+### Breaking changes
+
+- **Stata**: `wsga rdd` e-class return names standardized to match `wsga did`.
+  RDD previously posted `e(lb_g0)`, `e(ub_g0)`, `e(lb_g1)`, `e(ub_g1)`,
+  `e(lb_diff)`, `e(ub_diff)`, `e(pval0)`, `e(pval1)`, `e(pval_diff)`. These
+  are now `e(ci_lb_g0)`, `e(ci_ub_g0)`, `e(ci_lb_g1)`, `e(ci_ub_g1)`,
+  `e(ci_lb_diff)`, `e(ci_ub_diff)`, `e(p_g0)`, `e(p_g1)`, `e(p_diff)`,
+  matching what `wsga did` already returned. Downstream code reading these
+  values from `wsga rdd` must be updated.
+
+### Bug fixes
+
+- **Stata**: `wsga rdd` now overwrites `e(p_g0)`, `e(p_g1)`, `e(p_diff)`,
+  `e(ci_lb_g0)`, `e(ci_ub_g0)`, `e(ci_lb_g1)`, `e(ci_ub_g1)`, `e(ci_lb_diff)`,
+  `e(ci_ub_diff)` with the mode-aware locals after the display block.
+  Previously `_wsga_rdd_myboo` posted these unconditionally as empirical
+  percentiles, so when `normal` was specified the displayed CI columns and
+  p-values were correct but the e-class returns silently kept the empirical
+  values. Empirical mode is a no-op (#32).
+- **Stata**: stripped non-ASCII characters from `wsga.ado`, `wsga_rdd.sthlp`,
+  `wsga_did.sthlp`, and `NEWS.md` to satisfy the repository's ASCII-only
+  policy. No semantic content changed.
+
+### Internal
+
+- New `stata/tests/smoke_inference_modes.do`: 18 checks (9 RDD + 9 DiD)
+  asserting `e()` CI bounds and p-values differ between empirical and normal
+  modes (regression guard for #32). Now uses a unified key list across
+  both designs, courtesy of the rename above.
+
+---
+
 ## wsga 1.0.3 (2026-05-12)
 
 ### New features
@@ -38,7 +72,7 @@
 - **Stata**: `wsga did` now correctly wires up `ipsweight()` and `pscore()` as
   named output variables in the dataset (previously accepted but silently
   ignored) (#25).
-- **Stata**: `wsga did` now implements `comsup` — units outside the G=1
+- **Stata**: `wsga did` now implements `comsup` -- units outside the G=1
   propensity score range are excluded from estimation and a `comsup` variable
   is created in the dataset, matching RDD behavior. Common support is
   re-evaluated per bootstrap replicate (#25).
@@ -79,27 +113,27 @@
 
 ### New features
 
-- **`design = "did"`**: sharp 2-period DiD-SGA pipeline. New required arguments `unit`, `time`, `treat`; optional `post_value` (defaults to `max(time)`). Runs long-form TWFE with subgroup × post interactions, IPW reweighting, and pairs cluster bootstrap over units (Cameron-Gelbach-Miller) by default.
-- **`inference` argument**: three-mode inference — `"empirical"` (default with bootstrap, percentile CIs), `"normal"` (normal-approx from bootstrap SE), `"analytical"` (sandwich/cluster-robust, no bootstrap).
+- **`design = "did"`**: sharp 2-period DiD-SGA pipeline. New required arguments `unit`, `time`, `treat`; optional `post_value` (defaults to `max(time)`). Runs long-form TWFE with subgroup x post interactions, IPW reweighting, and pairs cluster bootstrap over units (Cameron-Gelbach-Miller) by default.
+- **`inference` argument**: three-mode inference -- `"empirical"` (default with bootstrap, percentile CIs), `"normal"` (normal-approx from bootstrap SE), `"analytical"` (sandwich/cluster-robust, no bootstrap).
 - **`fixed_ps`**: opt-in flag to hold the propensity score fixed at the original-sample fit across bootstrap replicates. Useful for variance decomposition. Default `FALSE`.
 - **`cluster_var`**: drives both analytical SEs and the bootstrap. DiD defaults to clustering on `unit`. One-time warning when fewer than 30 unique clusters are present.
-- **Bundled dataset**: `wsga_did_synth` — balanced 2-period panel of 500 units (seed = 7). True effects `tau_0 = 1`, `tau_1 = 3`.
+- **Bundled dataset**: `wsga_did_synth` -- balanced 2-period panel of 500 units (seed = 7). True effects `tau_0 = 1`, `tau_1 = 3`.
 - **DiD balance tables**: aggregate and treated-only (D = 1) balance, each unweighted and IPW-weighted.
 - **Vignette**: `vignette("wsga-did-intro")` walks through the full DiD workflow.
-- **`bsreps` default** bumped 50 → 200.
+- **`bsreps` default** bumped 50 -> 200.
 
 ### Breaking changes
 
-- Balance accessor: `fit$balance$unweighted$table` → `fit$balance$unweighted$aggregate$table` (nested structure to accommodate the DiD treated-only block).
+- Balance accessor: `fit$balance$unweighted$table` -> `fit$balance$unweighted$aggregate$table` (nested structure to accommodate the DiD treated-only block).
 - Default `bsreps` changed from 50 to 200.
 
 ### Package rename (from rddsga)
 
-- Package renamed `rddsga` → `wsga`. The old function `rddsga()` was retained as a deprecated alias (now forwards to `wsga_rdd()`). Plan to remove in v2.
+- Package renamed `rddsga` -> `wsga`. The old function `rddsga()` was retained as a deprecated alias (now forwards to `wsga_rdd()`). Plan to remove in v2.
 
 ---
 
-## rddsga 0.3.0 → wsga 0.6.x (internal milestones)
+## rddsga 0.3.0 -> wsga 0.6.x (internal milestones)
 
 - Umbrella refactor: single `wsga()` entry point dispatching both RD and DiD paths (replaced by `wsga_rdd()` / `wsga_did()` in 1.0.0).
 - S3 methods: `print`, `summary`, `coef`, `vcov`, `confint`, `nobs`.
@@ -110,7 +144,7 @@
 
 ---
 
-## rddsga 0.2.x / 0.3.0 (2018–2023)
+## rddsga 0.2.x / 0.3.0 (2018-2023)
 
 Initial CRAN-adjacent R implementation of the RDD-SGA estimator accompanying
 the working paper "Weighted Subgroup Analysis in Regression Discontinuity

--- a/stata/rddsga.ado
+++ b/stata/rddsga.ado
@@ -1,4 +1,4 @@
-*! 1.0.3 Alvaro Carril 2026-05-12
+*! 1.1.0 Alvaro Carril 2026-05-25
 program define rddsga
   version 11.1
   di as error "rddsga is removed. Use {cmd:wsga rdd} instead."

--- a/stata/rddsga.pkg
+++ b/stata/rddsga.pkg
@@ -1,4 +1,4 @@
-v 1.0.3
+v 1.1.0
 d 'RDDSGA': Deprecated alias for the wsga package
 d
 d  rddsga is the previous name of the wsga (Weighted Subgroup Analysis)
@@ -18,7 +18,7 @@ d KW: IPW
 d
 d Requires: Stata version 11
 d
-d Distribution-Date: 20260512
+d Distribution-Date: 20260525
 d
 d Authors: Alvaro Carril
 d          Andre Cazor, PUC Chile

--- a/stata/rddsga.sthlp
+++ b/stata/rddsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.0.3 2026-05-12}{...}
+{* *! version 1.1.0 2026-05-25}{...}
 {title:Title}
 
 {pstd}

--- a/stata/stata.toc
+++ b/stata/stata.toc
@@ -1,4 +1,4 @@
-v 1.0.3
+v 1.1.0
 d Alvaro Carril
 p wsga Weighted subgroup analysis (RD designs; sharp DiD planned)
 p rddsga (deprecated alias of wsga; installs the same files)

--- a/stata/tests/smoke_inference_modes.do
+++ b/stata/tests/smoke_inference_modes.do
@@ -1,0 +1,53 @@
+// smoke_inference_modes.do -- e-class CI bounds and p-values must respect
+// the `normal' option, for both RDD and DiD (issue #32).
+//
+// Run from rddsga-repo/:
+//   stata-mp -b do stata/tests/smoke_inference_modes.do && cat smoke_inference_modes.log
+
+quietly do stata/wsga.ado
+
+local n_fail = 0
+local tol = 1e-10
+local keys ci_lb_g0 ci_ub_g0 ci_lb_g1 ci_ub_g1 ci_lb_diff ci_ub_diff p_g0 p_g1 p_diff
+
+// -- RDD
+use stata/rddsga_synth, clear
+wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform bsreps(200) seed(42) noipsw
+foreach q of local keys {
+  scalar rdd_`q'_emp = e(`q')
+}
+wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform bsreps(200) seed(42) noipsw normal
+foreach q of local keys {
+  scalar d = abs(rdd_`q'_emp - e(`q'))
+  if d < `tol' {
+    di as error "FAIL [RDD e(`q')]: identical across modes (emp=" rdd_`q'_emp ", nrm=" e(`q') ")"
+    local ++n_fail
+  }
+  else {
+    di as result "PASS [RDD e(`q')]: differs by " d
+  }
+}
+
+// -- DiD (regression guard; was already correct prior to #32)
+use stata/wsga_did_synth, clear
+wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) bsreps(50) seed(42) noipsw
+foreach q of local keys {
+  scalar did_`q'_emp = e(`q')
+}
+wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) bsreps(50) seed(42) noipsw normal
+foreach q of local keys {
+  scalar d = abs(did_`q'_emp - e(`q'))
+  if d < `tol' {
+    di as error "FAIL [DiD e(`q')]: identical across modes (emp=" did_`q'_emp ", nrm=" e(`q') ")"
+    local ++n_fail
+  }
+  else {
+    di as result "PASS [DiD e(`q')]: differs by " d
+  }
+}
+
+if `n_fail' == 0 di as result _newline "All inference-mode e-return checks passed."
+else {
+  di as error _newline "`n_fail' check(s) FAILED."
+  exit 1
+}

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,6 +1,6 @@
-*! 1.0.3 Alvaro Carril 2026-05-12
+*! 1.1.0 Alvaro Carril 2026-05-25
 
-// ── Dispatcher ────────────────────────────────────────────────────────────────
+// -- Dispatcher ----------------------------------------------------------------
 program define wsga
   version 11.1
   gettoken sub rest : 0, parse(" ")
@@ -18,7 +18,7 @@ program define wsga
   }
 end
 
-// ── RDD implementation ────────────────────────────────────────────────────────
+// -- RDD implementation --------------------------------------------------------
 program define _wsga_rdd, eclass
 version 11.1
 syntax varlist(min=1 numeric fv) [if] [in], ///
@@ -30,7 +30,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     noBOOTstrap bsreps(real 200) FIXEDbootstrap FIXEDps BLOCKbootstrap(string) NORMal noipsw weights(string) ///
     Seed(string) ]
 
-// ─── Validate required options ────────────────────────────────────────────────
+// --- Validate required options ------------------------------------------------
 if `bwidth' < 0 {
   di as error "bwidth() is required and must be positive."
   exit 198
@@ -39,7 +39,7 @@ if ("`ivregress'" != "" | "`firststage'" != "") & "`fuzzy'" == "" {
   di as error "fuzzy() must be specified with ivregress or firststage."
   exit 198
 }
-// ──────────────────────────────────────────────────────────────────────────────
+// ------------------------------------------------------------------------------
 
 *-------------------------------------------------------------------------------
 * Check inputs
@@ -536,9 +536,9 @@ if "`ivregress'" != "" | "`reducedform'" != "" | "`firststage'" != "" {
       }
       else {
         // Empirical (percentile) bootstrap CIs and (1+count)/(B+1) p-values
-        scalar p_g`g'     = e(pval`g')
-        scalar ci_lb_g`g' = e(lb_g`g')
-        scalar ci_ub_g`g' = e(ub_g`g')
+        scalar p_g`g'     = e(p_g`g')
+        scalar ci_lb_g`g' = e(ci_lb_g`g')
+        scalar ci_ub_g`g' = e(ci_ub_g`g')
       }
     }
     else {
@@ -568,15 +568,30 @@ if "`ivregress'" != "" | "`reducedform'" != "" | "`firststage'" != "" {
     }
     else {
       // Empirical (percentile) bootstrap CIs and (1+count)/(B+1) p-values
-      scalar p_diff     = e(pval_diff)
-      scalar ci_lb_diff = e(lb_diff)
-      scalar ci_ub_diff = e(ub_diff)
+      scalar p_diff     = e(p_diff)
+      scalar ci_lb_diff = e(ci_lb_diff)
+      scalar ci_ub_diff = e(ci_ub_diff)
     }
   }
   else {
     scalar p_diff     = ttail(df, abs(t_diff))*2
     scalar ci_lb_diff = b_diff + invttail(df, 0.975)*se_diff
     scalar ci_ub_diff = b_diff + invttail(df, 0.025)*se_diff
+  }
+
+  // #32: _wsga_rdd_myboo posts these as empirical percentiles. Overwrite
+  // with mode-aware locals so e() matches the displayed CI columns.
+  // Empirical mode is a no-op (locals were just read from e()).
+  if "`bootstrap'" != "nobootstrap" {
+    ereturn scalar p_g0      = p_g0
+    ereturn scalar p_g1      = p_g1
+    ereturn scalar p_diff    = p_diff
+    ereturn scalar ci_lb_g0  = ci_lb_g0
+    ereturn scalar ci_ub_g0  = ci_ub_g0
+    ereturn scalar ci_lb_g1  = ci_lb_g1
+    ereturn scalar ci_ub_g1  = ci_ub_g1
+    ereturn scalar ci_lb_diff = ci_lb_diff
+    ereturn scalar ci_ub_diff = ci_ub_diff
   }
 
 
@@ -836,7 +851,7 @@ program define _wsga_rdd_myboo, eclass
       if abs(bscoef - b[1,`=`g'+1']) >= abs(b[1,`=`g'+1']) local count = `count'+1
     }
     scalar pval`g' = (1+`count') / (`B' + 1)
-    ereturn scalar pval`g' = pval`g'
+    ereturn scalar p_g`g' = pval`g'
   }
   // Empirical p-value for diff (column 3)
   scalar orig_diff = b[1,2] - b[1,1]
@@ -846,24 +861,24 @@ program define _wsga_rdd_myboo, eclass
     if abs(bscoef - orig_diff) >= abs(orig_diff) local count_diff = `count_diff' + 1
   }
   scalar pval_diff = (1 + `count_diff') / (`B' + 1)
-  ereturn scalar pval_diff = pval_diff
+  ereturn scalar p_diff = pval_diff
   // Empirical confidence intervals
   svmat cumulative, names(_subgroup)
   forvalues g = 0/1 {
     qui centile _subgroup`=`g'+1', centile(2.5 97.5)
     drop _subgroup`=`g'+1'
     scalar lb_g`g' = r(c_1)
-    ereturn scalar lb_g`g' = lb_g`g'
+    ereturn scalar ci_lb_g`g' = lb_g`g'
     scalar ub_g`g' = r(c_2)
-    ereturn scalar ub_g`g' = ub_g`g'
+    ereturn scalar ci_ub_g`g' = ub_g`g'
   }
   // Empirical CI for diff (column 3)
   qui centile _subgroup3, centile(2.5 97.5)
   drop _subgroup3
   scalar lb_diff = r(c_1)
-  ereturn scalar lb_diff = lb_diff
+  ereturn scalar ci_lb_diff = lb_diff
   scalar ub_diff = r(c_2)
-  ereturn scalar ub_diff = ub_diff
+  ereturn scalar ci_ub_diff = ub_diff
   // Post results: macros
   foreach macro of local macros {
     if "`macro'" == "clustvar" continue
@@ -1151,11 +1166,11 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     WILDcluster ///
     NORMal noipsw weights(string) Seed(string) ]
 
-  // ── Sample mask
+  // -- Sample mask
   marksample touse, novarlist
   markout `touse' `unit' `time' `treat' `sgroup'
 
-  // ── wildcluster validation: requires the bootstrap loop (it IS the loop).
+  // -- wildcluster validation: requires the bootstrap loop (it IS the loop).
   if "`wildcluster'" != "" & "`bootstrap'" == "nobootstrap" {
     di as error ///
 "option {bf:wildcluster} requires the bootstrap loop; cannot be combined with {bf:nobootstrap}."
@@ -1166,7 +1181,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
 "Note: {bf:blockbootstrap} is ignored under {bf:wildcluster} (Rademacher signs are drawn unstratified)."
   }
 
-  // ── Outcome and covariates
+  // -- Outcome and covariates
   local depvar : word 1 of `varlist'
   local covariates : list varlist - depvar
 
@@ -1176,7 +1191,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
   if "`pscore'" != "" confirm new variable `pscore'
   else tempvar pscore
 
-  // ── Validate: time has exactly 2 unique non-missing values
+  // -- Validate: time has exactly 2 unique non-missing values
   qui levelsof `time' if `touse', local(t_vals)
   local n_tvals : word count `t_vals'
   if `n_tvals' != 2 {
@@ -1185,7 +1200,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     exit 198
   }
 
-  // ── Resolve post_value
+  // -- Resolve post_value
   if "`post_value'" == "" {
     qui summarize `time' if `touse', meanonly
     local post_value = r(max)
@@ -1202,7 +1217,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     }
   }
 
-  // ── Unit-constancy checks (treat, sgroup, balance moderators, blockbootstrap)
+  // -- Unit-constancy checks (treat, sgroup, balance moderators, blockbootstrap)
   foreach v in `treat' `sgroup' `balance' `blockbootstrap' {
     tempvar _dist
     qui by `unit' (`v'), sort: gen byte `_dist' = (`v'[1] != `v'[_N])
@@ -1215,7 +1230,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     drop `_dist'
   }
 
-  // ── Build design variables
+  // -- Build design variables
   tempvar G0 G1 post G0_Z G1_Z G0_post G1_post
   qui gen byte `G0'      = (`sgroup' == 0)
   qui gen byte `G1'      = (`sgroup' == 1)
@@ -1225,7 +1240,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
   qui gen byte `G0_post' = `G0' * `post'
   qui gen byte `G1_post' = `G1' * `post'
 
-  // ── Covariate × G interactions
+  // -- Covariate - G interactions
   local g0_covs ""
   local g1_covs ""
   foreach v of local covariates {
@@ -1236,9 +1251,9 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     local g1_covs "`g1_covs' `g1_`v''"
   }
 
-  // ── IPW: fit logit/probit on (G, balance) and compute weights.
+  // -- IPW: fit logit/probit on (G, balance) and compute weights.
   // Because G and the moderators are unit-constant (validated above), fitting
-  // on the long panel produces unit-constant pscore values — the per-row
+  // on the long panel produces unit-constant pscore values - the per-row
   // values are correct as-is and no broadcast is required.
   // When comsup is specified, units outside the G=1 pscore range are excluded.
   qui gen double `pscore'    = .
@@ -1301,7 +1316,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     qui replace `ipsweight' = 0 if mi(`ipsweight')
   }
 
-  // ── Estimate: long-form TWFE with unit FE absorbed via xtreg, fe.
+  // -- Estimate: long-form TWFE with unit FE absorbed via xtreg, fe.
   // Weights enter as pweights so SE machinery is consistent with sampling-
   // weight semantics.  When noipsw / no balance, ipsweight is identically 1.
   qui xtset `unit'
@@ -1310,7 +1325,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
   tempvar _did_esample
   gen byte `_did_esample' = e(sample)
 
-  // ── Extract coefficients of interest
+  // -- Extract coefficients of interest
   scalar b_g0   = _b[`G0_Z']
   scalar b_g1   = _b[`G1_Z']
   scalar b_diff = b_g1 - b_g0
@@ -1339,7 +1354,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
   scalar ci_lb_diff = b_diff + invttail(df, 0.975)*se_diff
   scalar ci_ub_diff = b_diff + invttail(df, 0.025)*se_diff
 
-  // ── Cluster bootstrap.
+  // -- Cluster bootstrap.
   // Two paths:
   //   - Pairs (default): whole units are resampled with replacement; fresh
   //     unit IDs are assigned via bsample's idcluster() so unit FE remain
@@ -1388,7 +1403,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
       qui use `_wsga_did_panel', clear
       capture {
         if "`wildcluster'" != "" {
-          // ─── WCB-U: Rademacher signs, one per unit, broadcast to all rows.
+          // --- WCB-U: Rademacher signs, one per unit, broadcast to all rows.
           tempvar _wsga_u _wsga_sign _wsga_ystar
           qui by `unit', sort: gen double `_wsga_u' = runiform() if _n == 1
           qui by `unit': replace `_wsga_u' = `_wsga_u'[1]
@@ -1533,7 +1548,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     restore
   }
 
-  // ── Display
+  // -- Display
   local _stat_label = cond(use_bootstrap, "z", "t")
   local _p_label    = cond(use_bootstrap, "P>|z|", "P>|t|")
   local _ci_tag     = cond(use_bootstrap & "`normal'" == "", " (emp.)", "")
@@ -1586,9 +1601,9 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
        as text "' (" as result %4.0f N_clust as text " clusters)"
   }
 
-  // ── Balance tables (aggregate + treated-only).  Per Q9a, in DiD mode
+  // -- Balance tables (aggregate + treated-only).  Per Q9a, in DiD mode
   // balance is reported both on the full active sample and conditional on
-  // treat == 1 — the paper recommends checking the treated-only table since
+  // treat == 1 - the paper recommends checking the treated-only table since
   // the parallel-trends assumption is on the treated.
   if `: list sizeof balance' > 0 {
     forvalues _bidx = 1/2 {
@@ -1642,7 +1657,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     }
   }
 
-  // ── Post clean e(b)/e(V) trimmed to the two treatment-effect columns.
+  // -- Post clean e(b)/e(V) trimmed to the two treatment-effect columns.
   // Analytic case: cov_01 comes from xtreg's VCV.
   // Bootstrap case: cov_01 is overwritten above with the bootstrap covariance.
   matrix _b_did = (b_g0, b_g1)

--- a/stata/wsga.pkg
+++ b/stata/wsga.pkg
@@ -1,4 +1,4 @@
-v 1.0.3
+v 1.1.0
 d 'WSGA': Weighted subgroup analysis
 d
 d  wsga conducts weighted subgroup analysis for research designs that
@@ -23,7 +23,7 @@ d KW: Inverse probability weighting
 d
 d Requires: Stata version 11
 d
-d Distribution-Date: 20260512
+d Distribution-Date: 20260525
 d
 d Authors: Alvaro Carril
 d          Andre Cazor, PUC Chile

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.0.3 2026-05-12}{...}
+{* *! version 1.1.0 2026-05-25}{...}
 {title:Title}
 
 {pstd}

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.0.3 2026-05-12}{...}
+{* *! version 1.1.0 2026-05-25}{...}
 {viewerjumpto "Stored results" "wsga_did##results"}{...}
 {title:Title}
 
@@ -30,7 +30,7 @@
 {syntab:IPW}
 {synopt:{opt balance(varlist)}}moderators for propensity score; defaults to covariates{p_end}
 {synopt:{opt noipsw}}skip IPW reweighting{p_end}
-{synopt:{opt m(#)}}weighting mode: 2 = both groups (default), 1 = G1→G0, 0 = G0→G1{p_end}
+{synopt:{opt m(#)}}weighting mode: 2 = both groups (default), 1 = G1->G0, 0 = G0->G1{p_end}
 {synopt:{opt probit}}use probit instead of logit for propensity score{p_end}
 {synopt:{opt comsup}}restrict to common propensity score support (units outside the G=1 pscore range are dropped from estimation){p_end}
 {synopt:{opt ipsweight(newvar)}}save IPW weights to {it:newvar} in the dataset{p_end}
@@ -59,7 +59,7 @@ across subgroups.
 
 {pstd}
 The cluster bootstrap resamples whole units with replacement and assigns fresh
-unit IDs per draw so fixed effects remain identified (Cameron–Gelbach–Miller).
+unit IDs per draw so fixed effects remain identified (Cameron-Gelbach-Miller).
 Clustering is always on {it:unit}.
 
 

--- a/stata/wsga_rdd.sthlp
+++ b/stata/wsga_rdd.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.0.3 2026-05-12}{...}
+{* *! version 1.1.0 2026-05-25}{...}
 {title:Title}
 
 {pstd}
@@ -33,7 +33,7 @@
 {syntab:IPW}
 {synopt:{opt balance(varlist)}}moderators for propensity score; defaults to covariates{p_end}
 {synopt:{opt noipsw}}skip IPW reweighting{p_end}
-{synopt:{opt m(#)}}weighting mode: 2 = both groups (default), 1 = G1→G0, 0 = G0→G1{p_end}
+{synopt:{opt m(#)}}weighting mode: 2 = both groups (default), 1 = G1->G0, 0 = G0->G1{p_end}
 {synopt:{opt probit}}use probit instead of logit for propensity score{p_end}
 {synopt:{opt comsup}}restrict to common propensity score support{p_end}
 {synopt:{opt dibalance}}display balance tables{p_end}


### PR DESCRIPTION
Two related Stata changes in this PR. The fix for #32 motivated the work; while in the file I noticed the naming asymmetry between RDD and DiD e-returns and standardized it here too.

## 1. Bug fix (#32)

`_wsga_rdd_myboo` posted `e()` CI bounds and p-values as empirical percentiles regardless of the `normal` option, so the displayed CI columns differed correctly across modes but the e-class returns silently kept the empirical values. `_wsga_rdd` now overwrites them with the mode-aware locals after the display block. Empirical mode is a no-op (locals were just read from `e()`). DiD path was already correct.

## 2. Breaking change: unified e-return naming

RDD e-return names standardized to match DiD. Where `wsga rdd` previously posted:

| Old (`wsga rdd`) | New (matches `wsga did`) |
|---|---|
| `e(lb_g0)` / `e(ub_g0)` | `e(ci_lb_g0)` / `e(ci_ub_g0)` |
| `e(lb_g1)` / `e(ub_g1)` | `e(ci_lb_g1)` / `e(ci_ub_g1)` |
| `e(lb_diff)` / `e(ub_diff)` | `e(ci_lb_diff)` / `e(ci_ub_diff)` |
| `e(pval0)` / `e(pval1)` / `e(pval_diff)` | `e(p_g0)` / `e(p_g1)` / `e(p_diff)` |

The `ci_` prefix is more self-documenting; `p_g*` reads cleaner than `pval*`. Downstream code reading these values from `wsga rdd` must update. User base is small (authors only), so the migration cost is acceptable.

## Other changes

- New `stata/tests/smoke_inference_modes.do`: 18 checks across both designs (9 RDD + 9 DiD), now using a single unified key list since names are symmetric.
- Stripped non-ASCII characters from `wsga.ado`, `wsga_rdd.sthlp`, `wsga_did.sthlp`, and `NEWS.md` per the repo's ASCII-only policy. No semantic content changed.
- Version bump 1.0.3 -> 1.1.0 (minor; breaking e-return contract).

Closes #32.

## Test plan

- [x] `stata-mp -b do stata/tests/smoke_rdd.do` (PASS)
- [x] `stata-mp -b do stata/tests/smoke_did.do` (PASS)
- [x] `stata-mp -b do stata/tests/smoke_did_wild.do` (PASS)
- [x] `stata-mp -b do stata/tests/smoke_inference_modes.do` (PASS, 18/18)
- [ ] CI: `R CMD check` on macOS / Windows / Ubuntu (release + devel)