### PR TITLE
feat(Stata/rdd): cluster() and wildcluster bootstrap options (#30)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 1.1.0
+Version: 1.2.0
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,47 @@
 # wsga (R package) NEWS
 
+## wsga 1.2.0 (2026-05-26)
+
+### New features
+
+- **Stata**: `wsga rdd` gains two new bootstrap options matching `wsga did`:
+  - `cluster(varname)` -- pairs-cluster bootstrap. Whole clusters are
+    resampled with replacement (`bsample, cluster()`). Composes cleanly
+    with `blockbootstrap()` for stratified cluster resampling. No silent
+    default: clustering must be specified explicitly.
+  - `wildcluster` -- unrestricted wild cluster bootstrap (WCB-U) with
+    Rademacher signs at the cluster level. Conditions on the data, sign-flips
+    the residuals from the main fit, refits on `y_star = xb + sign * resid`.
+    Recommended at small G (<~30 clusters), where pairs over-rejects under
+    H0 (Cameron, Gelbach & Miller 2008). Requires `cluster()`. Not supported
+    with `ivregress` (fuzzy RD via 2SLS); WCB on a 2SLS fit needs a different
+    recipe (#30).
+- **Stata**: `wsga rdd` now emits a G<30 advisory when `cluster()` is set
+  and there are fewer than 30 unique clusters, recommending `wildcluster`.
+  Mirrors the existing DiD advisory.
+- **Stata**: `wsga rdd` posts new e-class results: `e(B_ok)` (successful
+  bootstrap reps), `e(N_clust)` (cluster count, when `cluster()` set),
+  `e(boot_type)` (`pairs` or `wild`), `e(clustvar)` (clustering variable
+  name).
+- **Stata**: `wsga rdd` display label now distinguishes
+  `Bootstrap replications` / `Cluster bootstrap` / `Wild cluster bootstrap`
+  to match what was actually run.
+
+### Documentation
+
+- `wsga_rdd.sthlp` gains a "Stored results" section mirroring
+  `wsga_did.sthlp`, plus examples for `cluster()` and `wildcluster`.
+
+### Internal
+
+- New `stata/tests/smoke_rdd_wild.do`: 8 checks covering pairs-cluster
+  bookkeeping, wildcluster runs and bookkeeping, pairs no-cluster
+  unchanged, validation errors (wildcluster+nobootstrap,
+  wildcluster-without-cluster, wildcluster+ivregress), seed reproducibility,
+  and the G<30 advisory path.
+
+---
+
 ## wsga 1.1.0 (2026-05-25)
 
 ### Breaking changes

--- a/stata/rddsga.ado
+++ b/stata/rddsga.ado
@@ -1,4 +1,4 @@
-*! 1.1.0 Alvaro Carril 2026-05-25
+*! 1.2.0 Alvaro Carril 2026-05-26
 program define rddsga
   version 11.1
   di as error "rddsga is removed. Use {cmd:wsga rdd} instead."

--- a/stata/rddsga.pkg
+++ b/stata/rddsga.pkg
@@ -1,4 +1,4 @@
-v 1.1.0
+v 1.2.0
 d 'RDDSGA': Deprecated alias for the wsga package
 d
 d  rddsga is the previous name of the wsga (Weighted Subgroup Analysis)
@@ -18,7 +18,7 @@ d KW: IPW
 d
 d Requires: Stata version 11
 d
-d Distribution-Date: 20260525
+d Distribution-Date: 20260526
 d
 d Authors: Alvaro Carril
 d          Andre Cazor, PUC Chile

--- a/stata/rddsga.sthlp
+++ b/stata/rddsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.1.0 2026-05-25}{...}
+{* *! version 1.2.0 2026-05-26}{...}
 {title:Title}
 
 {pstd}

--- a/stata/stata.toc
+++ b/stata/stata.toc
@@ -1,4 +1,4 @@
-v 1.1.0
+v 1.2.0
 d Alvaro Carril
 p wsga Weighted subgroup analysis (RD designs; sharp DiD planned)
 p rddsga (deprecated alias of wsga; installs the same files)

--- a/stata/tests/smoke_rdd_wild.do
+++ b/stata/tests/smoke_rdd_wild.do
@@ -1,0 +1,132 @@
+// smoke_rdd_wild.do -- tests for `wsga rdd, cluster() wildcluster`
+// Run from rddsga-repo/:
+//   stata-mp -b do stata/tests/smoke_rdd_wild.do && cat smoke_rdd_wild.log
+
+quietly do stata/wsga.ado
+use stata/rddsga_synth, clear
+
+// Synthetic clustering variable: 50 clusters of ~200 obs (G >= 30, no advisory)
+gen clust = ceil(_n/200)
+
+local n_fail = 0
+
+// -- TEST 1: pairs cluster runs and posts cluster bookkeeping --
+capture wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(50) seed(1) noipsw cluster(clust)
+if _rc != 0 {
+  di as error "FAIL [pairs cluster: runs]: rc=" _rc
+  local ++n_fail
+}
+else if "`e(boot_type)'" == "pairs" & e(N_clust) == 50 {
+  di as result "PASS [pairs cluster: boot_type=pairs, N_clust=50]"
+}
+else {
+  di as error "FAIL [pairs cluster: boot_type=`e(boot_type)', N_clust=" e(N_clust) "]"
+  local ++n_fail
+}
+
+// -- TEST 2: wildcluster runs and posts boot_type=wild --
+capture wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(50) seed(1) noipsw cluster(clust) wildcluster
+if _rc != 0 {
+  di as error "FAIL [wildcluster: runs]: rc=" _rc
+  local ++n_fail
+}
+else if "`e(boot_type)'" == "wild" & e(N_clust) == 50 {
+  di as result "PASS [wildcluster: boot_type=wild, N_clust=50]"
+}
+else {
+  di as error "FAIL [wildcluster: boot_type=`e(boot_type)', N_clust=" e(N_clust) "]"
+  local ++n_fail
+}
+
+// -- TEST 3: pairs path WITHOUT cluster still tags boot_type=pairs and N_clust=. --
+wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(30) seed(1) noipsw
+if "`e(boot_type)'" == "pairs" & mi(e(N_clust)) {
+  di as result "PASS [pairs no-cluster: boot_type=pairs, N_clust=.]"
+}
+else {
+  di as error "FAIL [pairs no-cluster: boot_type=`e(boot_type)', N_clust=" e(N_clust) "]"
+  local ++n_fail
+}
+
+// -- TEST 4: wildcluster + nobootstrap rejected --
+capture wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  noipsw cluster(clust) wildcluster nobootstrap
+if _rc != 0 {
+  di as result "PASS [wildcluster+nobootstrap rejected, rc=" _rc "]"
+}
+else {
+  di as error "FAIL [wildcluster+nobootstrap should have errored]"
+  local ++n_fail
+}
+
+// -- TEST 5: wildcluster without cluster() rejected --
+capture wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(20) seed(1) noipsw wildcluster
+if _rc != 0 {
+  di as result "PASS [wildcluster-without-cluster rejected, rc=" _rc "]"
+}
+else {
+  di as error "FAIL [wildcluster-without-cluster should have errored]"
+  local ++n_fail
+}
+
+// -- TEST 6: wildcluster + ivregress rejected (no WCB on 2SLS) --
+capture wsga rdd Y, sgroup(G) running(X) bwidth(10) ivregress fuzzy(D) ///
+  bsreps(20) seed(1) noipsw cluster(clust) wildcluster
+if _rc != 0 {
+  di as result "PASS [wildcluster+ivregress rejected, rc=" _rc "]"
+}
+else {
+  di as error "FAIL [wildcluster+ivregress should have errored]"
+  local ++n_fail
+}
+
+// -- TEST 7: seed makes wildcluster reproducible (compare bootstrap V) --
+wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(30) seed(42) noipsw cluster(clust) wildcluster
+scalar _v00_run1 = e(V)[1,1]
+scalar _v11_run1 = e(V)[2,2]
+scalar _ci_run1  = e(ci_lb_g0)
+
+wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(30) seed(42) noipsw cluster(clust) wildcluster
+scalar _v00_run2 = e(V)[1,1]
+scalar _v11_run2 = e(V)[2,2]
+scalar _ci_run2  = e(ci_lb_g0)
+
+if abs(_v00_run1 - _v00_run2) < 1e-10 & abs(_v11_run1 - _v11_run2) < 1e-10 ///
+   & abs(_ci_run1 - _ci_run2) < 1e-10 {
+  di as result "PASS [seed: wildcluster V and CI reproducible]"
+}
+else {
+  di as error "FAIL [seed: wildcluster reproducibility broken]"
+  di "  v00 diff: " abs(_v00_run1 - _v00_run2)
+  di "  v11 diff: " abs(_v11_run1 - _v11_run2)
+  di "  ci  diff: " abs(_ci_run1 - _ci_run2)
+  local ++n_fail
+}
+
+// -- TEST 8: G<30 advisory fires for pairs but not for wild (just runs without error) --
+preserve
+gen clust_small = ceil(_n/1000)
+qui wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(20) seed(1) noipsw cluster(clust_small)
+if e(N_clust) == 10 {
+  di as result "PASS [pairs small-G: N_clust=10 (advisory expected on screen)]"
+}
+else {
+  di as error "FAIL [pairs small-G: N_clust=" e(N_clust) "]"
+  local ++n_fail
+}
+restore
+
+if `n_fail' == 0 {
+  di as result _newline "All wsga rdd wildcluster smoke tests passed."
+}
+else {
+  di as error _newline "`n_fail' smoke test(s) FAILED."
+  exit 1
+}

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,4 +1,4 @@
-*! 1.1.0 Alvaro Carril 2026-05-25
+*! 1.2.0 Alvaro Carril 2026-05-26
 
 // -- Dispatcher ----------------------------------------------------------------
 program define wsga
@@ -28,6 +28,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     BALance(varlist numeric) DIBALance probit ///
     IVregress REDUCEDform FIRSTstage vce(string) p(int 1) m(int 2) rbalance(int 0) ///
     noBOOTstrap bsreps(real 200) FIXEDbootstrap FIXEDps BLOCKbootstrap(string) NORMal noipsw weights(string) ///
+    CLuster(varname) WILDcluster ///
     Seed(string) ]
 
 // --- Validate required options ------------------------------------------------
@@ -38,6 +39,25 @@ if `bwidth' < 0 {
 if ("`ivregress'" != "" | "`firststage'" != "") & "`fuzzy'" == "" {
   di as error "fuzzy() must be specified with ivregress or firststage."
   exit 198
+}
+if "`wildcluster'" != "" & "`bootstrap'" == "nobootstrap" {
+  di as error ///
+"option {bf:wildcluster} requires the bootstrap loop; cannot be combined with {bf:nobootstrap}."
+  exit 198
+}
+if "`wildcluster'" != "" & "`cluster'" == "" {
+  di as error ///
+"option {bf:wildcluster} requires {bf:cluster(varname)}; no natural default for RDD."
+  exit 198
+}
+if "`wildcluster'" != "" & "`ivregress'" != "" {
+  di as error ///
+"option {bf:wildcluster} is not supported with {bf:ivregress} (fuzzy RD via 2SLS); WCB on a 2SLS fit needs a different recipe."
+  exit 198
+}
+if "`wildcluster'" != "" & "`blockbootstrap'" != "" {
+  di as text ///
+"Note: {bf:blockbootstrap} is ignored under {bf:wildcluster} (Rademacher signs are drawn unstratified)."
 }
 // ------------------------------------------------------------------------------
 
@@ -338,6 +358,18 @@ if "`ipsw'" != "noipsw" & `: list sizeof balance' > 0 {
   if "`comsup'" != "" local psw_boot_opts `psw_boot_opts' comsup
 }
 if "`seed'" != "" local psw_boot_opts `psw_boot_opts' seed(`seed')
+if "`cluster'" != "" local psw_boot_opts `psw_boot_opts' cluster(`cluster')
+if "`wildcluster'" != "" local psw_boot_opts `psw_boot_opts' wildcluster
+
+// G < 30 advisory when clustering is active
+if "`cluster'" != "" & "`bootstrap'" != "nobootstrap" {
+  qui levelsof `cluster' if `touse' & `bwidth', local(_clusters)
+  local _N_clust : word count `_clusters'
+  if `_N_clust' < 30 & "`wildcluster'" == "" {
+    di as text ///
+"Note: pairs-cluster bootstrap with " as result %4.0f `_N_clust' as text " clusters.  With fewer than ~30 clusters, pairs over-rejects under H0; consider the {bf:wildcluster} option for better size control (Cameron, Gelbach & Miller 2008)."
+  }
+}
 
 * First stage
 *-------------------------------------------------------------------------------
@@ -713,7 +745,8 @@ end
 program define _wsga_rdd_myboo, eclass
   syntax anything [, PSW IPSWeight(name) KERNELipsw(name) KWT(name) ///
     TOuse(name) BWIDTH(string) BALance(varlist) OWeights(name) ///
-    M(integer 2) BINarymodel(string) PSCore(name) COmsup Seed(string)]
+    M(integer 2) BINarymodel(string) PSCore(name) COmsup Seed(string) ///
+    CLuster(varname) WILDcluster]
 
   local svar : word 1 of `anything'
   local cvar : word 2 of `anything'
@@ -738,15 +771,51 @@ program define _wsga_rdd_myboo, eclass
   matrix b = b[1, "0.`svar'#1.`cvar'".."1.`svar'#1.`cvar'"]
   matrix colnames b = 0.`svar'#1.`cvar' 1.`svar'#1.`cvar'
 
+  // -- Cluster bootstrap setup. Two paths share this myboo body:
+  //    - Pairs (default; cluster() optional): bsample resamples rows or whole
+  //      clusters with replacement; PS refit per replicate; refits e(cmdline).
+  //    - Wild (`wildcluster' + `cluster'): WCB-U with Rademacher signs at the
+  //      cluster level. Captures xb and residuals from the main fit, sign-flips
+  //      per replicate, refits e(cmdline) on y_star. No PS refit (conditions on
+  //      data; does not propagate IPW uncertainty -- intentional, CGM 2008).
+  local _saved_cmdline = e(cmdline)
+  local _saved_depvar  = e(depvar)
+  if "`wildcluster'" != "" {
+    tempvar _wsga_xb _wsga_resid
+    qui predict double `_wsga_xb'    if `esample', xb
+    qui predict double `_wsga_resid' if `esample', residuals
+  }
+
   // Start bootstrap
   di ""
-  _dots 0, title(Bootstrap replications) reps(`B')
+  local _boot_title = cond("`wildcluster'" != "", "Wild cluster bootstrap", ///
+                        cond("`cluster'" != "", "Cluster bootstrap", "Bootstrap replications"))
+  _dots 0, title(`_boot_title') reps(`B')
   cap mat drop cumulative
   if "`seed'" != "" set seed `seed'
   tempvar COMSUP_b
   forvalues i=1/`B' {
     preserve
-    bsample, strata(`e(blockbootstrap)')
+    if "`wildcluster'" != "" {
+      // WCB-U: draw one Rademacher sign per cluster, broadcast to rows,
+      // y_star = xb + sign * resid; refit on y_star.
+      tempvar _wsga_u _wsga_sign _wsga_ystar
+      qui by `cluster', sort: gen double `_wsga_u' = runiform() if _n == 1
+      qui by `cluster': replace `_wsga_u' = `_wsga_u'[1]
+      qui gen double `_wsga_sign'  = cond(`_wsga_u' < 0.5, -1, 1) if `esample'
+      qui gen double `_wsga_ystar' = `_wsga_xb' + `_wsga_sign' * `_wsga_resid' if `esample'
+      qui replace `_saved_depvar' = `_wsga_ystar' if `esample'
+      qui `_saved_cmdline'
+      // Skip PS refit block below; jump to coefficient extraction
+    }
+    else {
+      // Pairs bootstrap (with or without cluster, with or without strata)
+      if "`cluster'" != "" {
+        bsample, cluster(`cluster') strata(`e(blockbootstrap)')
+      }
+      else {
+        bsample, strata(`e(blockbootstrap)')
+      }
 
     // Re-estimate propensity score on bootstrap sample
     if "`psw'" != "" {
@@ -805,7 +874,8 @@ program define _wsga_rdd_myboo, eclass
       qui replace `kernelipsw' = `ipsweight' * `kwt'
     }
 
-    qui `e(cmdline)'
+      qui `e(cmdline)'
+    }
     tempname this_run
     // Non-IV or bootstrap-both-stages
     if IndIV[1,1]==0 | fixed[1,1]==0 {
@@ -833,6 +903,12 @@ program define _wsga_rdd_myboo, eclass
   // Add names to V
   mat rownames V = 0.`svar'#1.`cvar' 1.`svar'#1.`cvar'
   mat colnames V = 0.`svar'#1.`cvar' 1.`svar'#1.`cvar'
+  // Count clusters in the estimation sample BEFORE ereturn post (which
+  // consumes the esample tempvar).
+  if "`cluster'" != "" {
+    qui levelsof `cluster' if `esample', local(_clusters)
+    local _N_clust : word count `_clusters'
+  }
   // Return
   ereturn post, esample(`esample')
   // Post results: scalars
@@ -840,7 +916,13 @@ program define _wsga_rdd_myboo, eclass
     ereturn scalar `scalar' = ``scalar''
   }
   ereturn scalar N_reps = `B'
+  ereturn scalar B_ok   = `B'
   ereturn scalar level = 95
+  if "`cluster'" != "" {
+    ereturn scalar N_clust = `_N_clust'
+    ereturn local clustvar `cluster'
+  }
+  ereturn local boot_type = cond("`wildcluster'" != "", "wild", "pairs")
   // Empirical p-values for subgroups
   // Recentered: count draws where |draw - est| >= |est|, testing H0: coef=0
   cap scalar drop bscoef

--- a/stata/wsga.pkg
+++ b/stata/wsga.pkg
@@ -1,4 +1,4 @@
-v 1.1.0
+v 1.2.0
 d 'WSGA': Weighted subgroup analysis
 d
 d  wsga conducts weighted subgroup analysis for research designs that
@@ -23,7 +23,7 @@ d KW: Inverse probability weighting
 d
 d Requires: Stata version 11
 d
-d Distribution-Date: 20260525
+d Distribution-Date: 20260526
 d
 d Authors: Alvaro Carril
 d          Andre Cazor, PUC Chile

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.1.0 2026-05-25}{...}
+{* *! version 1.2.0 2026-05-26}{...}
 {title:Title}
 
 {pstd}

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.1.0 2026-05-25}{...}
+{* *! version 1.2.0 2026-05-26}{...}
 {viewerjumpto "Stored results" "wsga_did##results"}{...}
 {title:Title}
 

--- a/stata/wsga_rdd.sthlp
+++ b/stata/wsga_rdd.sthlp
@@ -1,5 +1,6 @@
 {smcl}
-{* *! version 1.1.0 2026-05-25}{...}
+{* *! version 1.2.0 2026-05-26}{...}
+{viewerjumpto "Stored results" "wsga_rdd##results"}{...}
 {title:Title}
 
 {pstd}
@@ -43,6 +44,8 @@
 {synopt:{opt bsreps(#)}}bootstrap replications; default 200{p_end}
 {synopt:{opt normal}}normal-approximation CIs from bootstrap SE{p_end}
 {synopt:{opt seed(#)}}RNG seed for reproducibility{p_end}
+{synopt:{opt cluster(varname)}}clustering variable for pairs-cluster bootstrap{p_end}
+{synopt:{opt wildcluster}}wild cluster bootstrap (WCB-U) with Rademacher signs; requires {opt cluster}{p_end}
 {synopt:{opt fixedbootstrap}}fixed first-stage bootstrap for IV{p_end}
 {synopt:{opt fixedps}}hold propensity score fixed across bootstrap reps (diagnostic){p_end}
 {synopt:{opt blockbootstrap(varname)}}stratified block bootstrap{p_end}
@@ -73,6 +76,52 @@ subgroup-attributable component of the effect difference.
 
 {pstd}Fuzzy RD via 2SLS:{p_end}
 {phang2}{cmd:. wsga rdd Y, sgroup(G) running(X) bwidth(0.5) ivregress fuzzy(D) nobootstrap}{p_end}
+
+{pstd}Pairs-cluster bootstrap on school IDs:{p_end}
+{phang2}{cmd:. wsga rdd Y M, sgroup(G) running(X) bwidth(0.5) bsreps(200) cluster(school) seed(42)}{p_end}
+
+{pstd}Wild cluster bootstrap (recommended for small G):{p_end}
+{phang2}{cmd:. wsga rdd Y M, sgroup(G) running(X) bwidth(0.5) bsreps(200) cluster(school) wildcluster seed(42)}{p_end}
+
+
+{marker results}{...}
+{title:Stored results}
+
+{pstd}
+{cmd:wsga rdd} stores the following in {cmd:e()}:
+
+{synoptset 23 tabbed}{...}
+{p2col 5 23 26 2: Scalars}{p_end}
+{synopt:{cmd:e(p_g0)}}p-value for subgroup-0{p_end}
+{synopt:{cmd:e(p_g1)}}p-value for subgroup-1{p_end}
+{synopt:{cmd:e(p_diff)}}p-value for the difference{p_end}
+{synopt:{cmd:e(ci_lb_g0)}}95% confidence interval lower bound, subgroup-0{p_end}
+{synopt:{cmd:e(ci_ub_g0)}}95% confidence interval upper bound, subgroup-0{p_end}
+{synopt:{cmd:e(ci_lb_g1)}}95% confidence interval lower bound, subgroup-1{p_end}
+{synopt:{cmd:e(ci_ub_g1)}}95% confidence interval upper bound, subgroup-1{p_end}
+{synopt:{cmd:e(ci_lb_diff)}}95% confidence interval lower bound, difference{p_end}
+{synopt:{cmd:e(ci_ub_diff)}}95% confidence interval upper bound, difference{p_end}
+{synopt:{cmd:e(N_G0)}}number of observations in subgroup 0{p_end}
+{synopt:{cmd:e(N_G1)}}number of observations in subgroup 1{p_end}
+{synopt:{cmd:e(N_reps)}}(bootstrap) requested replications{p_end}
+{synopt:{cmd:e(B_ok)}}(bootstrap) successful replications{p_end}
+{synopt:{cmd:e(N_clust)}}(bootstrap, clustered) number of clusters{p_end}
+{synopt:{cmd:e(level)}}confidence level (95){p_end}
+
+{p2col 5 23 26 2: Macros}{p_end}
+{synopt:{cmd:e(cmd)}}{cmd:wsga}{p_end}
+{synopt:{cmd:e(subcmd)}}{cmd:rdd}{p_end}
+{synopt:{cmd:e(depvar)}}name of dependent variable{p_end}
+{synopt:{cmd:e(boot_type)}}(bootstrap) {cmd:pairs} or {cmd:wild}{p_end}
+{synopt:{cmd:e(clustvar)}}(bootstrap, clustered) clustering variable{p_end}
+{synopt:{cmd:e(blockbootstrap)}}(bootstrap, stratified) stratification variable{p_end}
+
+{p2col 5 23 26 2: Matrices}{p_end}
+{synopt:{cmd:e(b)}}1 x 2 coefficient row for ({cmd:G0_Z}, {cmd:G1_Z}){p_end}
+{synopt:{cmd:e(V)}}2 x 2 variance-covariance matrix; bootstrap-derived when bootstrap is on{p_end}
+
+{p2col 5 23 26 2: Functions}{p_end}
+{synopt:{cmd:e(sample)}}marks estimation sample{p_end}
 
 
 {title:See also}


### PR DESCRIPTION
Closes the Stata RDD wild-cluster-bootstrap work explicitly deferred in the v1.0.3 NEWS. After this PR, `wsga rdd` matches what `wsga did` already offered for clustered inference.

## New options on `wsga rdd`

- **`cluster(varname)`** -- pairs-cluster bootstrap. Whole clusters are resampled with replacement via `bsample, cluster()`. Composes with `blockbootstrap()` for stratified cluster resampling. **No silent default**: clustering must be specified explicitly, because picking the wrong cluster level silently is worse than a clear error.
- **`wildcluster`** -- unrestricted wild cluster bootstrap (WCB-U) with Rademacher signs at the cluster level. Captures `xb` and residuals from the main fit before the loop; per replicate, draws one sign per cluster, broadcasts to rows, computes `y_star = xb + sign * resid`, refits `e(cmdline)` on `y_star`. **No PS refit under WCB** (intentional; CGM 2008). Requires `cluster()`. Not supported with `ivregress` (fuzzy RD via 2SLS).

## Validation

- `wildcluster` + `nobootstrap` -> error.
- `wildcluster` without `cluster()` -> error.
- `wildcluster` + `ivregress` -> error (WCB on 2SLS needs a different recipe).

## Display + e-returns

- Loop label switches between `Bootstrap replications`, `Cluster bootstrap`, and `Wild cluster bootstrap`.
- G<30 advisory when `cluster()` is set and there are fewer than 30 clusters, recommending `wildcluster`.
- New `e()`: `e(B_ok)`, `e(N_clust)`, `e(boot_type)`, `e(clustvar)`. Match DiD's contract.

## Docs

- `wsga_rdd.sthlp` gains a Stored results section mirroring `wsga_did.sthlp`.
- Examples for both new options.

## R side

R already had `boot_type = "wild"` (PR #31). No R changes.

## Version

1.1.0 -> 1.2.0 (minor; new feature, no breaking).

## Test plan

- [x] `stata-mp -b do stata/tests/smoke_rdd.do` (PASS)
- [x] `stata-mp -b do stata/tests/smoke_did.do` (PASS)
- [x] `stata-mp -b do stata/tests/smoke_did_wild.do` (PASS)
- [x] `stata-mp -b do stata/tests/smoke_inference_modes.do` (PASS, 18/18)
- [x] `stata-mp -b do stata/tests/smoke_rdd_wild.do` (PASS, 8/8)
- [ ] CI: `R CMD check` on macOS / Windows / Ubuntu (release + devel)

## Issue #30 checklist

After this PR, the remaining items in #30 are paper-side only (inference section in the draft).