### PR TITLE
chore: codify release-per-version-bump in version-bump skill (v1.2.1)

### DIFF
--- a/.claude/skills/wsga-version-bump/SKILL.md
+++ b/.claude/skills/wsga-version-bump/SKILL.md
@@ -144,6 +144,38 @@ chore(release): bump version to X.Y.Z
 R and Stata DiD; see preceding commit and NEWS.md.">
 ```
 
+## Step 8 — Post-merge: tag and release on GitHub
+
+After the PR merges to `main`, create a GitHub release for the new version. Every version bump corresponds to a release — see the rationale in the repo's release strategy (R users can pin via `devtools::install_github("acarril/wsga@vX.Y.Z")`; methods papers citing the package need stable references).
+
+Triggered when the user (or you) confirms the merge has landed. Run from `main` after a `git pull`:
+
+```bash
+# Extract this version's NEWS section into a temp file
+awk -v v="X.Y.Z" '
+  $0 ~ "^## wsga " v " " { in_section = 1; next }
+  /^---$/ && in_section { exit }
+  in_section { print }
+' NEWS.md > /tmp/wsga_release_notes.md
+
+# Tag the merge commit (we are on main, so HEAD is the merge commit)
+git tag -a vX.Y.Z -m "wsga X.Y.Z"
+git push origin vX.Y.Z
+
+# Create the GH release
+gh release create vX.Y.Z --repo acarril/wsga \
+  --title "wsga X.Y.Z" \
+  --notes-file /tmp/wsga_release_notes.md
+```
+
+If you're backfilling releases for past version bumps (because the tag/release was missed earlier), tag at the merge commit of the PR that introduced that version. Find it via:
+
+```bash
+git log --first-parent main --oneline | grep "Merge pull request #<N>"
+```
+
+and pass the SHA as a positional argument to `git tag -a vX.Y.Z <sha> -m "..."`. The release is non-blocking — if the user wants to do it themselves through the GitHub UI, the tag+push is enough; they can `gh release create` later.
+
 ## Notes for the next maintainer
 
 - The version drift problem is real: in practice, the `.pkg` files and `stata.toc` have repeatedly fallen out of sync with `DESCRIPTION`. If you encounter drift mid-bump, target everything at the same new version and mention the drift in `NEWS.md` so the resolution is logged.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 1.2.0
+Version: 1.2.1
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # wsga (R package) NEWS
 
+## wsga 1.2.1 (2026-05-26)
+
+### Documentation
+
+- Update the `wsga-version-bump` skill to include a post-merge Step 8
+  for tagging the release commit and publishing it via `gh release create`.
+  Codifies the release-per-version-bump policy adopted retroactively when
+  v1.0.1 through v1.2.0 were backfilled.
+
+---
+
 ## wsga 1.2.0 (2026-05-26)
 
 ### New features

--- a/stata/rddsga.ado
+++ b/stata/rddsga.ado
@@ -1,4 +1,4 @@
-*! 1.2.0 Alvaro Carril 2026-05-26
+*! 1.2.1 Alvaro Carril 2026-05-26
 program define rddsga
   version 11.1
   di as error "rddsga is removed. Use {cmd:wsga rdd} instead."

--- a/stata/rddsga.pkg
+++ b/stata/rddsga.pkg
@@ -1,4 +1,4 @@
-v 1.2.0
+v 1.2.1
 d 'RDDSGA': Deprecated alias for the wsga package
 d
 d  rddsga is the previous name of the wsga (Weighted Subgroup Analysis)

--- a/stata/rddsga.sthlp
+++ b/stata/rddsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 2026-05-26}{...}
+{* *! version 1.2.1 2026-05-26}{...}
 {title:Title}
 
 {pstd}

--- a/stata/stata.toc
+++ b/stata/stata.toc
@@ -1,4 +1,4 @@
-v 1.2.0
+v 1.2.1
 d Alvaro Carril
 p wsga Weighted subgroup analysis (RD designs; sharp DiD planned)
 p rddsga (deprecated alias of wsga; installs the same files)

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,4 +1,4 @@
-*! 1.2.0 Alvaro Carril 2026-05-26
+*! 1.2.1 Alvaro Carril 2026-05-26
 
 // -- Dispatcher ----------------------------------------------------------------
 program define wsga

--- a/stata/wsga.pkg
+++ b/stata/wsga.pkg
@@ -1,4 +1,4 @@
-v 1.2.0
+v 1.2.1
 d 'WSGA': Weighted subgroup analysis
 d
 d  wsga conducts weighted subgroup analysis for research designs that

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 2026-05-26}{...}
+{* *! version 1.2.1 2026-05-26}{...}
 {title:Title}
 
 {pstd}

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 2026-05-26}{...}
+{* *! version 1.2.1 2026-05-26}{...}
 {viewerjumpto "Stored results" "wsga_did##results"}{...}
 {title:Title}
 

--- a/stata/wsga_rdd.sthlp
+++ b/stata/wsga_rdd.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 2026-05-26}{...}
+{* *! version 1.2.1 2026-05-26}{...}
 {viewerjumpto "Stored results" "wsga_rdd##results"}{...}
 {title:Title}
 


### PR DESCRIPTION
## Summary

Adds **Step 8 (post-merge: tag and release)** to the `wsga-version-bump` skill, codifying the release-per-version-bump policy we adopted retroactively when v1.0.1 through v1.2.0 were tagged + released as a single backfill batch.

## What changed

- `.claude/skills/wsga-version-bump/SKILL.md` -- new Step 8 documents the post-merge release flow:
  - Extract the NEWS section for the version via `awk`
  - `git tag -a vX.Y.Z` at the merge commit, push tag
  - `gh release create vX.Y.Z --notes-file ...`
  - Plus a backfill recipe for catching up missed releases.

## Why now

- Only `v1.0.0` had ever been released on GitHub; the other five versions on `main` were unreleased.
- R users need stable refs (`devtools::install_github("acarril/wsga@vX.Y.Z")`) for reproducibility in published work that uses the estimator.
- Skill now ensures this happens reflexively for future PRs.

## Version

1.2.0 -> **1.2.1** (patch; docs-only, no code change).

## Test plan

- [x] All 5 Stata smoke tests pass (no code touched; sanity check).
- [ ] CI: `R CMD check` on macOS / Windows / Ubuntu (release + devel).