### PR TITLE
fix(Stata/rdd): WCB refits on tempvar + reject missing cluster IDs (#37)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 1.2.1
+Version: 1.2.2
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,30 @@
 # wsga (R package) NEWS
 
+## wsga 1.2.2 (2026-05-26)
+
+### Bug fixes
+
+- **Stata** (`wsga rdd`, WCB path): the bootstrap loop no longer mutates
+  the user's outcome variable in place. Previously `_wsga_rdd_myboo` did
+  `replace <depvar> = <ystar>` inside `preserve/restore`, which was correct
+  in the happy path but left the outcome corrupted in memory if a replicate
+  errored between `replace` and `restore`. WCB now parses the cmdline once
+  via `gettoken` and refits as `<cmd> <ystar_tempvar> <rhs>` per replicate,
+  never touching the dataset's copy of the outcome (#37).
+- **Stata** (`wsga rdd`): missing cluster IDs in the estimation sample now
+  error out (`exit 198`) instead of being silently lumped into one implicit
+  group by `by cluster`. Matches R behavior. DiD is unaffected because
+  `markout touse unit time treat sgroup` already drops missing-unit rows
+  (#37).
+
+### Internal
+
+- New regression tests in `stata/tests/smoke_rdd_wild.do` (2 added, 10 total):
+  (a) `Y` is byte-for-byte unchanged after a WCB run, (b) missing cluster
+  IDs cause `wsga rdd` to error with `rc != 0`.
+
+---
+
 ## wsga 1.2.1 (2026-05-26)
 
 ### Documentation

--- a/stata/rddsga.ado
+++ b/stata/rddsga.ado
@@ -1,4 +1,4 @@
-*! 1.2.1 Alvaro Carril 2026-05-26
+*! 1.2.2 Alvaro Carril 2026-05-26
 program define rddsga
   version 11.1
   di as error "rddsga is removed. Use {cmd:wsga rdd} instead."

--- a/stata/rddsga.pkg
+++ b/stata/rddsga.pkg
@@ -1,4 +1,4 @@
-v 1.2.1
+v 1.2.2
 d 'RDDSGA': Deprecated alias for the wsga package
 d
 d  rddsga is the previous name of the wsga (Weighted Subgroup Analysis)

--- a/stata/rddsga.sthlp
+++ b/stata/rddsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.1 2026-05-26}{...}
+{* *! version 1.2.2 2026-05-26}{...}
 {title:Title}
 
 {pstd}

--- a/stata/stata.toc
+++ b/stata/stata.toc
@@ -1,4 +1,4 @@
-v 1.2.1
+v 1.2.2
 d Alvaro Carril
 p wsga Weighted subgroup analysis (RD designs; sharp DiD planned)
 p rddsga (deprecated alias of wsga; installs the same files)

--- a/stata/tests/smoke_rdd_wild.do
+++ b/stata/tests/smoke_rdd_wild.do
@@ -123,6 +123,37 @@ else {
 }
 restore
 
+// -- TEST 9: WCB does not mutate the user's outcome variable (#37) --
+preserve
+tempvar _Y_snapshot
+gen double `_Y_snapshot' = Y
+qui wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(20) seed(7) noipsw cluster(clust) wildcluster
+qui count if !mi(Y) & !mi(`_Y_snapshot') & abs(Y - `_Y_snapshot') > 1e-12
+if r(N) == 0 {
+  di as result "PASS [WCB does not mutate Y in dataset]"
+}
+else {
+  di as error "FAIL [WCB mutated " r(N) " rows of Y]"
+  local ++n_fail
+}
+restore
+
+// -- TEST 10: missing cluster IDs rejected (#37) --
+preserve
+gen clust_with_mi = clust
+qui replace clust_with_mi = . in 1/100
+capture wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(20) seed(1) noipsw cluster(clust_with_mi)
+if _rc != 0 {
+  di as result "PASS [missing-cluster rejected, rc=" _rc "]"
+}
+else {
+  di as error "FAIL [missing cluster IDs should have errored]"
+  local ++n_fail
+}
+restore
+
 if `n_fail' == 0 {
   di as result _newline "All wsga rdd wildcluster smoke tests passed."
 }

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,4 +1,4 @@
-*! 1.2.1 Alvaro Carril 2026-05-26
+*! 1.2.2 Alvaro Carril 2026-05-26
 
 // -- Dispatcher ----------------------------------------------------------------
 program define wsga
@@ -361,8 +361,16 @@ if "`seed'" != "" local psw_boot_opts `psw_boot_opts' seed(`seed')
 if "`cluster'" != "" local psw_boot_opts `psw_boot_opts' cluster(`cluster')
 if "`wildcluster'" != "" local psw_boot_opts `psw_boot_opts' wildcluster
 
-// G < 30 advisory when clustering is active
+// Cluster validation + G < 30 advisory when clustering is active
 if "`cluster'" != "" & "`bootstrap'" != "nobootstrap" {
+  // Missing cluster IDs in the active sample are not allowed (#37). Stata's
+  // `by cluster' would silently lump missings into one implicit group.
+  qui count if mi(`cluster') & `touse' & `bwidth'
+  if r(N) > 0 {
+    di as error ///
+"`cluster' has " r(N) " missing values in the estimation sample; cluster ID must be non-missing."
+    exit 198
+  }
   qui levelsof `cluster' if `touse' & `bwidth', local(_clusters)
   local _N_clust : word count `_clusters'
   if `_N_clust' < 30 & "`wildcluster'" == "" {
@@ -784,6 +792,11 @@ program define _wsga_rdd_myboo, eclass
     tempvar _wsga_xb _wsga_resid
     qui predict double `_wsga_xb'    if `esample', xb
     qui predict double `_wsga_resid' if `esample', residuals
+    // Parse the cmdline once so the WCB loop can refit on a tempvar y_star
+    // instead of mutating the user's outcome variable in place (#37).
+    // Cmdline shape after `regress' is: "<cmd> <depvar> <rhs ...>".
+    gettoken _wsga_cmd_name _wsga_cmd_rest : _saved_cmdline
+    gettoken _wsga_olddep   _wsga_cmd_rhs  : _wsga_cmd_rest
   }
 
   // Start bootstrap
@@ -798,14 +811,14 @@ program define _wsga_rdd_myboo, eclass
     preserve
     if "`wildcluster'" != "" {
       // WCB-U: draw one Rademacher sign per cluster, broadcast to rows,
-      // y_star = xb + sign * resid; refit on y_star.
+      // y_star = xb + sign * resid; refit `<cmd> y_star <rhs>` (#37: never
+      // touch the user's outcome variable).
       tempvar _wsga_u _wsga_sign _wsga_ystar
       qui by `cluster', sort: gen double `_wsga_u' = runiform() if _n == 1
       qui by `cluster': replace `_wsga_u' = `_wsga_u'[1]
       qui gen double `_wsga_sign'  = cond(`_wsga_u' < 0.5, -1, 1) if `esample'
       qui gen double `_wsga_ystar' = `_wsga_xb' + `_wsga_sign' * `_wsga_resid' if `esample'
-      qui replace `_saved_depvar' = `_wsga_ystar' if `esample'
-      qui `_saved_cmdline'
+      qui `_wsga_cmd_name' `_wsga_ystar' `_wsga_cmd_rhs'
       // Skip PS refit block below; jump to coefficient extraction
     }
     else {

--- a/stata/wsga.pkg
+++ b/stata/wsga.pkg
@@ -1,4 +1,4 @@
-v 1.2.1
+v 1.2.2
 d 'WSGA': Weighted subgroup analysis
 d
 d  wsga conducts weighted subgroup analysis for research designs that

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.1 2026-05-26}{...}
+{* *! version 1.2.2 2026-05-26}{...}
 {title:Title}
 
 {pstd}

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.1 2026-05-26}{...}
+{* *! version 1.2.2 2026-05-26}{...}
 {viewerjumpto "Stored results" "wsga_did##results"}{...}
 {title:Title}
 

--- a/stata/wsga_rdd.sthlp
+++ b/stata/wsga_rdd.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.1 2026-05-26}{...}
+{* *! version 1.2.2 2026-05-26}{...}
 {viewerjumpto "Stored results" "wsga_rdd##results"}{...}
 {title:Title}
 


### PR DESCRIPTION
Two related operational fragilities in the wild cluster bootstrap path for `wsga rdd`, both surfaced by the econometrics review on PR #35.

## 1. In-place depvar mutation under WCB

The bootstrap loop in `_wsga_rdd_myboo` did:

\`\`\`stata
qui replace \`_saved_depvar' = \`_wsga_ystar' if \`esample'
qui \`_saved_cmdline'
\`\`\`

inside `preserve/restore`. Correct in the happy path, but if a replicate errored between `replace` and `restore` (rare but possible: degenerate draw, `regress` failure, user interrupt), the outcome variable stayed corrupted in memory for the rest of the session.

**Fix**: parse the cmdline once at entry via `gettoken`, then refit per replicate as `\`_wsga_cmd_name' \`_wsga_ystar' \`_wsga_cmd_rhs'`. No `replace` on the user's depvar; the dataset's copy of the outcome is never touched.

## 2. Missing cluster IDs silently grouped

`qui by \`cluster', sort: gen ... if _n == 1` treats missing as its own group, broadcasting one Rademacher sign across all missing-cluster rows. Undocumented "missing-as-cluster" behavior.

**Fix**: in `_wsga_rdd`, validate non-missing cluster IDs in `touse & bwidth` before launching the bootstrap. Errors with rc=198 if any missing are found. Matches R behavior.

DiD is unaffected: `markout touse unit time treat sgroup` at the top of `_wsga_did` already drops missing-unit rows from `touse`.

## Tests

Two new regression checks in `smoke_rdd_wild.do` (now 10/10):
- `Y` is byte-for-byte unchanged after a WCB run.
- Missing cluster IDs cause `wsga rdd` to error with `rc != 0`.

## Version

1.2.1 -> **1.2.2** (patch).

## Test plan

- [x] `stata-mp -b do stata/tests/smoke_rdd.do` (PASS)
- [x] `stata-mp -b do stata/tests/smoke_did.do` (PASS)
- [x] `stata-mp -b do stata/tests/smoke_did_wild.do` (PASS)
- [x] `stata-mp -b do stata/tests/smoke_inference_modes.do` (PASS)
- [x] `stata-mp -b do stata/tests/smoke_rdd_wild.do` (PASS, 10/10)
- [ ] CI: `R CMD check` on macOS / Windows / Ubuntu (release + devel)

Closes #37.