### PR TITLE
feat(inference): add WCB-R restricted wild cluster bootstrap (R + Stata) v1.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 1.2.2
+Version: 1.3.0
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # wsga (R package) NEWS
 
+## wsga 1.3.0 (2026-05-26)
+
+### New features
+
+- **R + Stata**: add restricted wild cluster bootstrap (WCB-R) for better
+  size control at very small cluster counts (G < ~12), following MacKinnon
+  and Webb (2017, 2018). In R: `boot_type = "wild_restricted"`; in Stata:
+  `wcbrestricted` option on both `wsga rdd` and `wsga did`.
+- **Architecture**: WCB-R uses a combined loop -- unrestricted draws for
+  empirical percentile CIs (per coauthor agreement) and three restricted
+  draws (H0: G0=0, H0: G1=0, H0: G0=G1) for p-values. P-value formula
+  for restricted draws does not recenter (`|draw| >= |est|`), matching
+  MacKinnon-Webb eq. 8.
+- **Advisories updated**: G < 30 with `pairs` recommends `boot_type =
+  "wild"` (unchanged); G < 12 with `boot_type = "wild"` now recommends
+  `boot_type = "wild_restricted"` (#36).
+
+---
+
 ## wsga 1.2.2 (2026-05-26)
 
 ### Bug fixes

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -24,7 +24,7 @@ stratified_resample <- function(n, strata = NULL) {
 #'   cluster's stratum. If supplied, clusters are sampled with replacement
 #'   *within* each stratum.
 #' @return A vector of drawn cluster IDs, same length and type as
-#'   `unique_clusters`. Duplicates are expected — that's the whole point.
+#'   `unique_clusters`. Duplicates are expected -- that's the whole point.
 #' @noRd
 cluster_resample <- function(unique_clusters, cluster_strata = NULL) {
   if (is.null(cluster_strata)) return(sample(unique_clusters, replace = TRUE))
@@ -39,7 +39,7 @@ cluster_resample <- function(unique_clusters, cluster_strata = NULL) {
 
 #' Build a resampled dataset by replicating each drawn cluster's rows.
 #'
-#' Fresh-IDs recipe (Cameron–Gelbach–Miller): the cluster identifier column
+#' Fresh-IDs recipe (Cameron-Gelbach-Miller): the cluster identifier column
 #' is rewritten as `<orig_id>__d<j>` for the j-th draw, so a cluster drawn N
 #' times yields N distinct copies. Required for any downstream specification
 #' that uses cluster-level fixed effects (DiD); a no-op when there are no FE.
@@ -54,7 +54,7 @@ cluster_resample <- function(unique_clusters, cluster_strata = NULL) {
 #'   are also propagated to that column so unit FE remain identified when
 #'   two draws of the same cluster bring in overlapping units.
 #' @return A list with two elements:
-#'   - `data`: data frame with `length(drawn) × rows-per-cluster` rows.
+#'   - `data`: data frame with `length(drawn) x rows-per-cluster` rows.
 #'   - `orig_idx`: integer vector of the same length, where
 #'     `orig_idx[k]` is the row in the original `data` that the k-th
 #'     row of the resampled data came from. Used by the `fixed_ps`
@@ -91,7 +91,7 @@ build_cluster_rep_data <- function(data, cluster_var, cluster_ids, drawn,
 #'   `block_var`).
 #' - `cluster_var` set: pairs cluster bootstrap. Whole clusters are drawn
 #'   with replacement; each drawn cluster contributes all its rows; cluster
-#'   IDs are made unique per draw (Cameron–Gelbach–Miller). `block_var`, if
+#'   IDs are made unique per draw (Cameron-Gelbach-Miller). `block_var`, if
 #'   supplied, must be constant within `cluster_var` and is used to stratify
 #'   at the cluster level.
 #'
@@ -105,8 +105,8 @@ build_cluster_rep_data <- function(data, cluster_var, cluster_ids, drawn,
 #'   adapt: strata of rows when `cluster_var` is NULL, strata of clusters
 #'   otherwise.
 #' @param seed Optional integer RNG seed.
-#' @return A list with `draws`, `vcov`, `pval`, `ci`, `B_ok`, `failed`, and —
-#'   when `cluster_var` is set — `N_clusters`.
+#' @return A list with `draws`, `vcov`, `pval`, `ci`, `B_ok`, `failed`, and --
+#'   when `cluster_var` is set -- `N_clusters`.
 #' @noRd
 run_bootstrap <- function(run_one_rep, data, B, est,
                           cluster_var = NULL,
@@ -240,7 +240,8 @@ run_bootstrap <- function(run_one_rep, data, B, est,
 #' @noRd
 run_wild_bootstrap <- function(fit, X, y, w, active, cluster_vec,
                                coef_g0_name, coef_g1_name,
-                               B, seed = NULL) {
+                               B, seed = NULL,
+                               restricted = FALSE) {
   if (!is.null(seed)) set.seed(seed)
 
   # Restrict to active rows (the only rows that influenced the fit)
@@ -283,7 +284,7 @@ run_wild_bootstrap <- function(fit, X, y, w, active, cluster_vec,
   }
   cluster_idx <- match(as.character(c_a), as.character(unique_clusters))
 
-  # Cache QR of the weighted design -- refits are then a single qr.coef() call.
+  # Cache QR of the weighted unrestricted design -- each refit is one qr.coef().
   sqrt_w <- sqrt(w_a)
   X_w    <- sqrt_w * X_clean
   qr_X   <- qr(X_w)
@@ -291,26 +292,89 @@ run_wild_bootstrap <- function(fit, X, y, w, active, cluster_vec,
     stop("Wild cluster bootstrap: weighted design matrix is rank-deficient.")
   }
 
+  # WCB-R pre-computation: fit three restricted models and store their
+  # fitted values and residuals. Each restricted fit imposes one null hypothesis;
+  # the residuals are used to generate y* in the bootstrap loop.
+  if (restricted) {
+    .fit_restricted <- function(X_r, label) {
+      qr_r <- qr(sqrt_w * X_r)
+      if (qr_r$rank < ncol(X_r))
+        stop(sprintf("WCB-R: restricted design for %s is rank-deficient (thin subgroup?).", label))
+      beta_r <- qr.coef(qr_r, sqrt_w * y_a)
+      yhat_r <- as.numeric(X_r %*% beta_r)
+      list(yhat = yhat_r, resid = y_a - yhat_r)
+    }
+
+    # H0: G0_Z = 0  -- drop the G0 treatment column
+    r0 <- .fit_restricted(
+      X_clean[, non_aliased != coef_g0_name, drop = FALSE], "H0: G0_Z=0")
+
+    # H0: G1_Z = 0  -- drop the G1 treatment column
+    r1 <- .fit_restricted(
+      X_clean[, non_aliased != coef_g1_name, drop = FALSE], "H0: G1_Z=0")
+
+    # H0: G0_Z = G1_Z  -- merge both treatment columns into Z_pooled = G0_Z + G1_Z
+    other_cols <- non_aliased[non_aliased != coef_g0_name & non_aliased != coef_g1_name]
+    X_rdiff <- cbind(
+      Z_pooled = X_clean[, coef_g0_name] + X_clean[, coef_g1_name],
+      X_clean[, other_cols, drop = FALSE]
+    )
+    rdiff <- .fit_restricted(X_rdiff, "H0: G0_Z=G1_Z")
+
+    draws_r0    <- rep(NA_real_, B)
+    draws_r1    <- rep(NA_real_, B)
+    draws_rdiff <- rep(NA_real_, B)
+  }
+
   draws <- matrix(NA_real_, nrow = B, ncol = 2,
                   dimnames = list(NULL, c("g0", "g1")))
 
-  message(sprintf("Wild cluster bootstrap (%d):", B))
+  label <- if (restricted) "WCB-R" else "WCB-U"
+  message(sprintf("Wild cluster bootstrap (%s, %d):", label, B))
   for (i in seq_len(B)) {
-    signs   <- sample(c(-1, 1), N_clusters, replace = TRUE)
-    v       <- signs[cluster_idx]
-    y_star  <- y_hat + v * e
-    y_w     <- sqrt_w * y_star
-    beta_b  <- tryCatch(qr.coef(qr_X, y_w), error = function(e) NULL)
+    signs <- sample(c(-1, 1), N_clusters, replace = TRUE)
+    v     <- signs[cluster_idx]
+
+    # Unrestricted refit: draws used for CI and SE (same as plain WCB-U)
+    y_star <- y_hat + v * e
+    beta_b <- tryCatch(qr.coef(qr_X, sqrt_w * y_star), error = function(e) NULL)
     if (!is.null(beta_b)) {
       names(beta_b) <- non_aliased
       draws[i, "g0"] <- beta_b[[coef_g0_name]]
       draws[i, "g1"] <- beta_b[[coef_g1_name]]
     }
+
+    if (restricted) {
+      # Restricted refit for H0: G0_Z=0 -- draw of G0_Z used for p-value
+      b_r0 <- tryCatch(
+        qr.coef(qr_X, sqrt_w * (r0$yhat + v * r0$resid)), error = function(e) NULL)
+      if (!is.null(b_r0)) {
+        names(b_r0) <- non_aliased
+        draws_r0[i] <- b_r0[[coef_g0_name]]
+      }
+
+      # Restricted refit for H0: G1_Z=0 -- draw of G1_Z
+      b_r1 <- tryCatch(
+        qr.coef(qr_X, sqrt_w * (r1$yhat + v * r1$resid)), error = function(e) NULL)
+      if (!is.null(b_r1)) {
+        names(b_r1) <- non_aliased
+        draws_r1[i] <- b_r1[[coef_g1_name]]
+      }
+
+      # Restricted refit for H0: G0_Z=G1_Z -- draw of diff
+      b_rdiff <- tryCatch(
+        qr.coef(qr_X, sqrt_w * (rdiff$yhat + v * rdiff$resid)), error = function(e) NULL)
+      if (!is.null(b_rdiff)) {
+        names(b_rdiff) <- non_aliased
+        draws_rdiff[i] <- b_rdiff[[coef_g1_name]] - b_rdiff[[coef_g0_name]]
+      }
+    }
+
     if (i %% 10 == 0 || i == B) cat(sprintf("\r  %d/%d", i, B))
   }
   cat("\n")
 
-  ok       <- complete.cases(draws)
+  ok <- complete.cases(draws)
   if (any(!ok)) {
     warning(sprintf("%d of %d wild bootstrap replicates failed and were dropped.",
                     sum(!ok), B))
@@ -324,15 +388,34 @@ run_wild_bootstrap <- function(fit, X, y, w, active, cluster_vec,
                 g1 = beta_clean[[coef_g1_name]])
   est_all  <- c(est_all, diff = est_all[["g1"]] - est_all[["g0"]])
 
-  pval <- sapply(seq_len(3), function(g) {
-    cnt <- sum(abs(draws_ok[, g] - est_all[g]) >= abs(est_all[g]))
-    (1 + cnt) / (B_ok + 1)
-  })
-  names(pval) <- c("g0", "g1", "diff")
-
+  # CIs: empirical percentile from unrestricted draws (coauthor agreement)
   ci <- apply(draws_ok, 2, quantile, probs = c(0.025, 0.975))
   rownames(ci) <- c("lb", "ub")
 
-  list(draws = draws_ok, vcov = V_boot, pval = pval, ci = ci,
-       B_ok = B_ok, failed = sum(!ok), N_clusters = N_clusters)
+  if (restricted) {
+    # P-values from restricted draws: compare |draw| >= |est|, no recentering.
+    # Under H0 the restricted residuals are already centred at 0, so the
+    # bootstrap distribution is centred at 0 by construction (MacKinnon &
+    # Webb 2017, eq. 8).
+    ok_r0    <- !is.na(draws_r0)
+    ok_r1    <- !is.na(draws_r1)
+    ok_rdiff <- !is.na(draws_rdiff)
+    pval <- c(
+      g0   = (1 + sum(abs(draws_r0[ok_r0])       >= abs(est_all[["g0"]])))   / (sum(ok_r0)    + 1),
+      g1   = (1 + sum(abs(draws_r1[ok_r1])       >= abs(est_all[["g1"]])))   / (sum(ok_r1)    + 1),
+      diff = (1 + sum(abs(draws_rdiff[ok_rdiff])  >= abs(est_all[["diff"]]))) / (sum(ok_rdiff) + 1)
+    )
+    list(draws = draws_ok, vcov = V_boot, pval = pval, ci = ci,
+         B_ok = B_ok, failed = sum(!ok), N_clusters = N_clusters,
+         boot_type_pval = "wild_restricted", boot_type_ci = "wild")
+  } else {
+    # WCB-U: recentered formula (draws centred at est, not 0)
+    pval <- sapply(seq_len(3), function(g) {
+      cnt <- sum(abs(draws_ok[, g] - est_all[g]) >= abs(est_all[g]))
+      (1 + cnt) / (B_ok + 1)
+    })
+    names(pval) <- c("g0", "g1", "diff")
+    list(draws = draws_ok, vcov = V_boot, pval = pval, ci = ci,
+         B_ok = B_ok, failed = sum(!ok), N_clusters = N_clusters)
+  }
 }

--- a/R/wsga.R
+++ b/R/wsga.R
@@ -49,13 +49,21 @@ NULL
 #' @param bootstrap Logical. Run the bootstrap loop (refits the full pipeline
 #'   per replicate)? Default `TRUE`.
 #' @param bsreps Positive integer: number of bootstrap replications. Default `200`.
-#' @param boot_type Character. Bootstrap resampling scheme: `"pairs"` (default)
-#'   or `"wild"`. `"wild"` runs an unrestricted wild cluster bootstrap with
-#'   Rademacher signs and is recommended when the number of clusters is small
-#'   (G < ~30); requires `cluster_var` to be set and is not supported with
-#'   `model = "iv"`. WCB conditions on the data and does not re-estimate the
-#'   propensity score, so it trades some IPW-uncertainty coverage for better
-#'   size control under H0.
+#' @param boot_type Character. Bootstrap resampling scheme:
+#'   - `"pairs"` (default): pairs cluster bootstrap; re-estimates the
+#'     propensity score per replicate, propagating IPW uncertainty.
+#'   - `"wild"`: unrestricted wild cluster bootstrap (WCB-U) with Rademacher
+#'     signs. Recommended when G < ~30. Conditions on the data and does not
+#'     re-estimate the propensity score.
+#'   - `"wild_restricted"`: restricted wild cluster bootstrap (WCB-R). For
+#'     each null hypothesis, y* is formed from residuals of the model fit
+#'     under H0; the unrestricted model is then refit on y* to obtain the
+#'     test statistic. P-values use `(1 + count) / (B+1)` with no
+#'     recentering; CIs remain empirical percentile from unrestricted draws.
+#'     Recommended when G < ~12 for better size control (MacKinnon and Webb
+#'     2017, 2018).
+#'   Both wild variants require `cluster_var` and are not supported with
+#'   `model = "iv"`.
 #' @param inference Character. How standard errors, CIs, and p-values are
 #'   computed and reported. One of:
 #'   - `"empirical"`: bootstrap SE; empirical (percentile) CIs at 2.5/97.5;
@@ -71,7 +79,7 @@ NULL
 #'   `cluster_var`: when `cluster_var` is `NULL`, `block_var` defines strata
 #'   of rows; when `cluster_var` is set, it defines strata of clusters and
 #'   must be constant within each cluster (validated at runtime). Ignored
-#'   when `boot_type = "wild"`.
+#'   when `boot_type` is `"wild"` or `"wild_restricted"`.
 #' @param fixed_fs Logical. Fixed first-stage bootstrap for IV: bootstrap the
 #'   reduced form and divide by the point-estimate first-stage coefficients.
 #'   Default `FALSE`.
@@ -247,15 +255,14 @@ wsga_rdd <- function(formula,
 #'   Default `FALSE`.
 #' @param bootstrap Logical. Run the bootstrap loop? Default `TRUE`.
 #' @param bsreps Positive integer: number of bootstrap replications. Default `200`.
-#' @param boot_type Character. Bootstrap resampling scheme: `"pairs"` (default)
-#'   or `"wild"` (unrestricted wild cluster bootstrap with Rademacher signs).
-#'   `"wild"` is recommended when the number of clusters is small (G < ~30).
-#'   See [wsga_rdd()] for the IPW-uncertainty caveat.
+#' @param boot_type Character. Bootstrap resampling scheme: `"pairs"` (default),
+#'   `"wild"` (WCB-U; recommended for G < ~30), or `"wild_restricted"` (WCB-R;
+#'   recommended for G < ~12). See [wsga_rdd()] for full details.
 #' @param inference Character. One of `"empirical"` (default with bootstrap),
 #'   `"normal"`, or `"analytical"` (default without bootstrap).
 #' @param block_var Character or `NULL`. Column name for stratified bootstrap
 #'   resampling (strata of clusters when `cluster_var` is set). Default `NULL`.
-#'   Ignored when `boot_type = "wild"`.
+#'   Ignored when `boot_type` is `"wild"` or `"wild_restricted"`.
 #' @param fixed_ps Logical. Diagnostic flag; see [wsga_rdd()] for details.
 #'   Default `FALSE`.
 #' @param seed Integer or `NULL`. RNG seed for reproducibility. Default `NULL`.

--- a/R/wsga.R
+++ b/R/wsga.R
@@ -55,14 +55,14 @@ NULL
 #'   (G < ~30); requires `cluster_var` to be set and is not supported with
 #'   `model = "iv"`. WCB conditions on the data and does not re-estimate the
 #'   propensity score, so it trades some IPW-uncertainty coverage for better
-#'   size control under H₀.
+#'   size control under H0.
 #' @param inference Character. How standard errors, CIs, and p-values are
 #'   computed and reported. One of:
 #'   - `"empirical"`: bootstrap SE; empirical (percentile) CIs at 2.5/97.5;
 #'     `(1 + count)/(B + 1)` p-values. Requires `bootstrap = TRUE`. **Default
 #'     when `bootstrap = TRUE`.**
-#'   - `"normal"`: bootstrap SE; normal-approximation CIs `b ± z·SE` and
-#'     p-values `2·(1 − Φ(|t|))`. Requires `bootstrap = TRUE`.
+#'   - `"normal"`: bootstrap SE; normal-approximation CIs `b +/- z*SE` and
+#'     p-values `2*(1 - Phi(|t|))`. Requires `bootstrap = TRUE`.
 #'   - `"analytical"`: sandwich (or cluster-robust) SE; CIs and p-values from
 #'     the t distribution with the regression residual df. Requires
 #'     `bootstrap = FALSE`. **Default when `bootstrap = FALSE`.**
@@ -93,7 +93,7 @@ NULL
 #'   Drives two things: when `bootstrap = TRUE`, switches the bootstrap from
 #'   row-level to pairs cluster (whole clusters are resampled with
 #'   replacement; cluster IDs are made unique per draw so unit fixed effects
-#'   remain identified — the Cameron–Gelbach–Miller recipe). When
+#'   remain identified -- the Cameron-Gelbach-Miller recipe). When
 #'   `inference = "analytical"`, also requires `vce = "cluster"` to deliver
 #'   the cluster-robust sandwich SE. With fewer than ~30 unique clusters, a
 #'   one-time warning is emitted about likely SE understatement; see
@@ -112,8 +112,8 @@ NULL
 #'     `inference`.}
 #'   \item{`ci`}{Named list of 95% confidence intervals, computed according to
 #'     `inference`.}
-#'   \item{`vcov`}{2×2 variance-covariance matrix for (g0, g1).}
-#'   \item{`bootstrap`}{List with `draws` (B×3 matrix), `vcov`, `pval`, `ci`,
+#'   \item{`vcov`}{2x2 variance-covariance matrix for (g0, g1).}
+#'   \item{`bootstrap`}{List with `draws` (Bx3 matrix), `vcov`, `pval`, `ci`,
 #'     `B_ok` (surviving reps), `failed` (dropped reps). `NULL` if
 #'     `bootstrap = FALSE`.}
 #'   \item{`inference`}{Character: the inference mode in effect.}
@@ -165,7 +165,7 @@ wsga_rdd <- function(formula,
                      rbalance     = 0L,
                      bootstrap    = TRUE,
                      bsreps       = 200L,
-                     boot_type    = c("pairs", "wild"),
+                     boot_type    = c("pairs", "wild", "wild_restricted"),
                      inference    = NULL,
                      block_var    = NULL,
                      fixed_fs     = FALSE,
@@ -299,7 +299,7 @@ wsga_did <- function(formula,
                      show_balance = FALSE,
                      bootstrap    = TRUE,
                      bsreps       = 200L,
-                     boot_type    = c("pairs", "wild"),
+                     boot_type    = c("pairs", "wild", "wild_restricted"),
                      inference    = NULL,
                      block_var    = NULL,
                      fixed_ps     = FALSE,
@@ -362,7 +362,7 @@ wsga_did <- function(formula,
                    rbalance    = 0L,
                    bootstrap   = TRUE,
                    bsreps      = 200L,
-                   boot_type   = c("pairs", "wild"),
+                   boot_type   = c("pairs", "wild", "wild_restricted"),
                    inference   = NULL,
                    block_var   = NULL,
                    fixed_fs    = FALSE,
@@ -372,7 +372,7 @@ wsga_did <- function(formula,
                    cluster_var = NULL,
                    weights     = NULL) {
 
-  # ── 1. Argument validation ──────────────────────────────────────────────────
+  # -- 1. Argument validation --------------------------------------------------
   design    <- match.arg(design)
   model     <- match.arg(model)
   kernel    <- match.arg(kernel)
@@ -412,7 +412,7 @@ wsga_did <- function(formula,
   if (!bootstrap && inference %in% c("empirical", "normal"))
     stop(sprintf("`inference = '%s'` requires `bootstrap = TRUE`.", inference))
 
-  # ── 2. Parse formula ────────────────────────────────────────────────────────
+  # -- 2. Parse formula --------------------------------------------------------
   fml <- Formula::Formula(formula)
   if (length(fml)[2] != 2)
     stop("`formula` must be two-part: outcome ~ covariates | subgroup")
@@ -459,18 +459,18 @@ wsga_did <- function(formula,
   # WCB conditions on the data and only sign-flips residuals at the cluster
   # level, so a cluster identifier is essential and the implementation is
   # restricted to lm-based estimators (no 2SLS yet).
-  if (identical(boot_type, "wild")) {
+  if (boot_type %in% c("wild", "wild_restricted")) {
     if (!bootstrap)
-      stop("`boot_type = \"wild\"` requires `bootstrap = TRUE` (the wild bootstrap is itself the bootstrap loop).")
+      stop(sprintf("`boot_type = \"%s\"` requires `bootstrap = TRUE` (the wild bootstrap is itself the bootstrap loop).", boot_type))
     if (is.null(cluster_var))
-      stop("`boot_type = \"wild\"` requires a clustering variable; set `cluster_var` (in DiD this defaults to `unit`).")
+      stop(sprintf("`boot_type = \"%s\"` requires a clustering variable; set `cluster_var` (in DiD this defaults to `unit`).", boot_type))
     if (model == "iv")
-      stop("`boot_type = \"wild\"` is not supported with `model = \"iv\"` (fuzzy RDD). Use `boot_type = \"pairs\"` or set `model` to `\"rf\"` / `\"fs\"`.")
+      stop(sprintf("`boot_type = \"%s\"` is not supported with `model = \"iv\"` (fuzzy RDD). Use `boot_type = \"pairs\"` or set `model` to `\"rf\"` / `\"fs\"`.", boot_type))
   }
 
   # For DiD with a cluster variable in play, the analytical SE should be
   # cluster-robust.  If the user left `vce` at its package default ("HC1")
-  # — i.e., didn't ask for something specific — switch it to "cluster" so
+  # -- i.e., didn't ask for something specific -- switch it to "cluster" so
   # `inference = "analytical"` doesn't silently report HC1 SEs that
   # under-estimate clustered variance.
   if (design == "did" && !is.null(cluster_var) && identical(vce, "HC1")) {
@@ -489,7 +489,7 @@ wsga_did <- function(formula,
     post_value <- did_val$post_value
   }
 
-  # ── 3. Extract vectors ───────────────────────────────────────────────────────
+  # -- 3. Extract vectors -------------------------------------------------------
   y <- data[[outcome_name]]
   G <- data[[sgroup_name]]
   if (!all(G %in% c(0, 1, NA)))
@@ -507,7 +507,7 @@ wsga_did <- function(formula,
     Z  <- D * post_vec   # serves as the "treatment indicator" for downstream
   }
 
-  # ── 4. Sample masks ─────────────────────────────────────────────────────────
+  # -- 4. Sample masks ---------------------------------------------------------
   if (design == "rdd") {
     touse     <- !is.na(y) & !is.na(x) & !is.na(G)
     within_bw <- abs(x) < bwidth
@@ -517,7 +517,7 @@ wsga_did <- function(formula,
     within_bw <- rep(TRUE, nrow(data))
   }
 
-  # ── 5. Kernel weights (RDD only; DiD uses unit weights of 1 × obs_wt) ───────
+  # -- 5. Kernel weights (RDD only; DiD uses unit weights of 1 x obs_wt) -------
   if (design == "rdd") {
     kwt <- kernel_weights(x, bwidth, kernel, obs_weights)
   } else {
@@ -525,7 +525,7 @@ wsga_did <- function(formula,
            else as.numeric(obs_weights)
   }
 
-  # ── 6. Propensity score + IPW ────────────────────────────────────────────────
+  # -- 6. Propensity score + IPW ------------------------------------------------
   if (!noipsw && length(balance_names) > 0) {
     bal_mat <- data[, balance_names, drop = FALSE]
 
@@ -561,12 +561,12 @@ wsga_did <- function(formula,
   N_G0_unw <- sum(touse & within_bw & G == 0)
   N_G1_unw <- sum(touse & within_bw & G == 1)
 
-  # ── 7. Balance tables ────────────────────────────────────────────────────────
+  # -- 7. Balance tables --------------------------------------------------------
   balance_result <- NULL
   if (length(balance_names) > 0) {
     # Helper: one balance-table computation for a given touse mask.
     one_balance <- function(touse_mask, N_G0, N_G1, weighted_only = FALSE) {
-      # Effective rbalance — for DiD, only "mean in sample" makes sense
+      # Effective rbalance -- for DiD, only "mean in sample" makes sense
       # (no cutoff to extrapolate to).
       rb <- if (design == "rdd") rbalance else 1L
       unw_w <- replace(kwt * coerce_obs_wt(obs_weights, nrow(data)),
@@ -631,7 +631,7 @@ wsga_did <- function(formula,
     )
   }
 
-  # ── 8. Design matrix + estimation ────────────────────────────────────────────
+  # -- 8. Design matrix + estimation --------------------------------------------
   # For model = "fs" (RDD only), outcome is the fuzzy treatment variable
   outcome_for_model <- if (model == "fs") fuzzy_name else outcome_name
 
@@ -690,24 +690,28 @@ wsga_did <- function(formula,
                            df_resid   = if (model != "iv") model_result$fit$df.residual else NULL,
                            use_normal = FALSE)
 
-  # ── 9. Bootstrap ─────────────────────────────────────────────────────────────
+  # -- 9. Bootstrap -------------------------------------------------------------
   boot_result <- NULL
   if (bootstrap) {
     point_est <- c(est$b_g0, est$b_g1)
 
-    # Few-clusters advisory when clustering is active (under pairs only;
-    # WCB is the recommended fix for this regime).
-    if (!is.null(cluster_var) && boot_type == "pairs") {
+    # Few-clusters advisories.
+    if (!is.null(cluster_var)) {
       n_clust <- length(unique(data[[cluster_var]][!is.na(data[[cluster_var]])]))
-      if (n_clust < 30L) {
+      if (boot_type == "pairs" && n_clust < 30L) {
         warning(sprintf(
           "Pairs-cluster bootstrap with %d clusters. With fewer than ~30 clusters, pairs over-rejects under H0; consider `boot_type = \"wild\"` for better size control (Cameron, Gelbach & Miller 2008).",
+          n_clust
+        ))
+      } else if (boot_type == "wild" && n_clust < 12L) {
+        warning(sprintf(
+          "Wild cluster bootstrap (WCB-U) with %d clusters. With fewer than ~12 clusters, the restricted variant has better size control; consider `boot_type = \"wild_restricted\"` (MacKinnon & Webb 2017).",
           n_clust
         ))
       }
     }
 
-    if (boot_type == "wild") {
+    if (boot_type %in% c("wild", "wild_restricted")) {
       boot_result <- run_wild_bootstrap(
         fit           = model_result$fit,
         X             = dm$X,
@@ -718,7 +722,8 @@ wsga_did <- function(formula,
         coef_g0_name  = model_result$coef_g0_name,
         coef_g1_name  = model_result$coef_g1_name,
         B             = bsreps,
-        seed          = seed
+        seed          = seed,
+        restricted    = identical(boot_type, "wild_restricted")
       )
     } else {
       # Closure capturing all configuration for one bootstrap replicate
@@ -795,7 +800,7 @@ wsga_did <- function(formula,
     }
   }
 
-  # ── 10. Assemble output ──────────────────────────────────────────────────────
+  # -- 10. Assemble output ------------------------------------------------------
   data$.wsga_x <- NULL  # clean up
 
   nobs <- c(
@@ -844,7 +849,7 @@ wsga_did <- function(formula,
 }
 
 
-# ── Helper: build bootstrap-replicate closure ──────────────────────────────────
+# -- Helper: build bootstrap-replicate closure ----------------------------------
 make_boot_rep <- function(design = "rdd",
                           outcome_name, running_name, cutoff, bwidth,
                           unit_name = NULL, time_name = NULL,
@@ -936,13 +941,13 @@ make_boot_rep <- function(design = "rdd",
 }
 
 
-# ── Helper: coerce obs_weights to a length-n vector ───────────────────────────
+# -- Helper: coerce obs_weights to a length-n vector ---------------------------
 coerce_obs_wt <- function(obs_weights, n) {
   if (is.null(obs_weights)) rep(1, n) else obs_weights
 }
 
 
-# ── Helper: DiD input validation ──────────────────────────────────────────────
+# -- Helper: DiD input validation ----------------------------------------------
 # Q9b checks. Returns the resolved `post_value` and an unbalanced-panel count.
 # Errors on hard violations; warns once on unbalanced panel.
 validate_did_data <- function(data, unit, time, treat, sgroup, balance,
@@ -1007,7 +1012,7 @@ validate_did_data <- function(data, unit, time, treat, sgroup, balance,
 }
 
 
-# ── S3 methods ────────────────────────────────────────────────────────────────
+# -- S3 methods ----------------------------------------------------------------
 
 #' @export
 print.wsga <- function(x, ...) {
@@ -1051,8 +1056,10 @@ print.wsga <- function(x, ...) {
 
   if (use_boot) {
     ps_tag <- if (isTRUE(x$fixed_ps)) " [PS fixed]" else ""
-    boot_label <- if (identical(x$boot_type, "wild")) "Wild cluster bootstrap"
-                  else "Cluster bootstrap"
+    boot_label <- switch(x$boot_type,
+                         wild             = "Wild cluster bootstrap (WCB-U)",
+                         wild_restricted  = "Wild cluster bootstrap (WCB-R)",
+                         "Cluster bootstrap")
     if (!is.null(x$bootstrap$N_clusters)) {
       total_reps <- x$bootstrap$B_ok + x$bootstrap$failed
       cat(sprintf("%s: %d/%d reps, clustered on '%s' (%d clusters)%s\n",

--- a/man/wsga_did.Rd
+++ b/man/wsga_did.Rd
@@ -19,7 +19,7 @@ wsga_did(
   show_balance = FALSE,
   bootstrap = TRUE,
   bsreps = 200L,
-  boot_type = c("pairs", "wild"),
+  boot_type = c("pairs", "wild", "wild_restricted"),
   inference = NULL,
   block_var = NULL,
   fixed_ps = FALSE,

--- a/man/wsga_did.Rd
+++ b/man/wsga_did.Rd
@@ -74,17 +74,16 @@ Default \code{FALSE}.}
 
 \item{bsreps}{Positive integer: number of bootstrap replications. Default \code{200}.}
 
-\item{boot_type}{Character. Bootstrap resampling scheme: \code{"pairs"} (default)
-or \code{"wild"} (unrestricted wild cluster bootstrap with Rademacher signs).
-\code{"wild"} is recommended when the number of clusters is small (G < ~30).
-See \code{\link[=wsga_rdd]{wsga_rdd()}} for the IPW-uncertainty caveat.}
+\item{boot_type}{Character. Bootstrap resampling scheme: \code{"pairs"} (default),
+\code{"wild"} (WCB-U; recommended for G < ~30), or \code{"wild_restricted"} (WCB-R;
+recommended for G < ~12). See \code{\link[=wsga_rdd]{wsga_rdd()}} for full details.}
 
 \item{inference}{Character. One of \code{"empirical"} (default with bootstrap),
 \code{"normal"}, or \code{"analytical"} (default without bootstrap).}
 
 \item{block_var}{Character or \code{NULL}. Column name for stratified bootstrap
 resampling (strata of clusters when \code{cluster_var} is set). Default \code{NULL}.
-Ignored when \code{boot_type = "wild"}.}
+Ignored when \code{boot_type} is \code{"wild"} or \code{"wild_restricted"}.}
 
 \item{fixed_ps}{Logical. Diagnostic flag; see \code{\link[=wsga_rdd]{wsga_rdd()}} for details.
 Default \code{FALSE}.}

--- a/man/wsga_rdd.Rd
+++ b/man/wsga_rdd.Rd
@@ -23,7 +23,7 @@ wsga_rdd(
   rbalance = 0L,
   bootstrap = TRUE,
   bsreps = 200L,
-  boot_type = c("pairs", "wild"),
+  boot_type = c("pairs", "wild", "wild_restricted"),
   inference = NULL,
   block_var = NULL,
   fixed_fs = FALSE,
@@ -103,7 +103,7 @@ Rademacher signs and is recommended when the number of clusters is small
 (G < ~30); requires \code{cluster_var} to be set and is not supported with
 \code{model = "iv"}. WCB conditions on the data and does not re-estimate the
 propensity score, so it trades some IPW-uncertainty coverage for better
-size control under H₀.}
+size control under H0.}
 
 \item{inference}{Character. How standard errors, CIs, and p-values are
 computed and reported. One of:
@@ -111,8 +111,8 @@ computed and reported. One of:
 \item \code{"empirical"}: bootstrap SE; empirical (percentile) CIs at 2.5/97.5;
 \code{(1 + count)/(B + 1)} p-values. Requires \code{bootstrap = TRUE}. \strong{Default
 when \code{bootstrap = TRUE}.}
-\item \code{"normal"}: bootstrap SE; normal-approximation CIs \verb{b ± z·SE} and
-p-values \verb{2·(1 − Φ(|t|))}. Requires \code{bootstrap = TRUE}.
+\item \code{"normal"}: bootstrap SE; normal-approximation CIs \verb{b +/- z*SE} and
+p-values \verb{2*(1 - Phi(|t|))}. Requires \code{bootstrap = TRUE}.
 \item \code{"analytical"}: sandwich (or cluster-robust) SE; CIs and p-values from
 the t distribution with the regression residual df. Requires
 \code{bootstrap = FALSE}. \strong{Default when \code{bootstrap = FALSE}.}
@@ -150,7 +150,7 @@ outcome specification when the PS fit is expensive. No effect when
 Drives two things: when \code{bootstrap = TRUE}, switches the bootstrap from
 row-level to pairs cluster (whole clusters are resampled with
 replacement; cluster IDs are made unique per draw so unit fixed effects
-remain identified — the Cameron–Gelbach–Miller recipe). When
+remain identified -- the Cameron-Gelbach-Miller recipe). When
 \code{inference = "analytical"}, also requires \code{vce = "cluster"} to deliver
 the cluster-robust sandwich SE. With fewer than ~30 unique clusters, a
 one-time warning is emitted about likely SE understatement; see
@@ -171,8 +171,8 @@ An S3 object of class \code{"wsga"} with the following elements:
 \code{inference}.}
 \item{\code{ci}}{Named list of 95\% confidence intervals, computed according to
 \code{inference}.}
-\item{\code{vcov}}{2×2 variance-covariance matrix for (g0, g1).}
-\item{\code{bootstrap}}{List with \code{draws} (B×3 matrix), \code{vcov}, \code{pval}, \code{ci},
+\item{\code{vcov}}{2x2 variance-covariance matrix for (g0, g1).}
+\item{\code{bootstrap}}{List with \code{draws} (Bx3 matrix), \code{vcov}, \code{pval}, \code{ci},
 \code{B_ok} (surviving reps), \code{failed} (dropped reps). \code{NULL} if
 \code{bootstrap = FALSE}.}
 \item{\code{inference}}{Character: the inference mode in effect.}

--- a/man/wsga_rdd.Rd
+++ b/man/wsga_rdd.Rd
@@ -97,13 +97,23 @@ per replicate)? Default \code{TRUE}.}
 
 \item{bsreps}{Positive integer: number of bootstrap replications. Default \code{200}.}
 
-\item{boot_type}{Character. Bootstrap resampling scheme: \code{"pairs"} (default)
-or \code{"wild"}. \code{"wild"} runs an unrestricted wild cluster bootstrap with
-Rademacher signs and is recommended when the number of clusters is small
-(G < ~30); requires \code{cluster_var} to be set and is not supported with
-\code{model = "iv"}. WCB conditions on the data and does not re-estimate the
-propensity score, so it trades some IPW-uncertainty coverage for better
-size control under H0.}
+\item{boot_type}{Character. Bootstrap resampling scheme:
+\itemize{
+\item \code{"pairs"} (default): pairs cluster bootstrap; re-estimates the
+propensity score per replicate, propagating IPW uncertainty.
+\item \code{"wild"}: unrestricted wild cluster bootstrap (WCB-U) with Rademacher
+signs. Recommended when G < ~30. Conditions on the data and does not
+re-estimate the propensity score.
+\item \code{"wild_restricted"}: restricted wild cluster bootstrap (WCB-R). For
+each null hypothesis, y* is formed from residuals of the model fit
+under H0; the unrestricted model is then refit on y* to obtain the
+test statistic. P-values use \code{(1 + count) / (B+1)} with no
+recentering; CIs remain empirical percentile from unrestricted draws.
+Recommended when G < ~12 for better size control (MacKinnon and Webb
+2017, 2018).
+Both wild variants require \code{cluster_var} and are not supported with
+\code{model = "iv"}.
+}}
 
 \item{inference}{Character. How standard errors, CIs, and p-values are
 computed and reported. One of:
@@ -123,7 +133,7 @@ resampling. Default \code{NULL} (unstratified). Semantics adapt to
 \code{cluster_var}: when \code{cluster_var} is \code{NULL}, \code{block_var} defines strata
 of rows; when \code{cluster_var} is set, it defines strata of clusters and
 must be constant within each cluster (validated at runtime). Ignored
-when \code{boot_type = "wild"}.}
+when \code{boot_type} is \code{"wild"} or \code{"wild_restricted"}.}
 
 \item{fixed_fs}{Logical. Fixed first-stage bootstrap for IV: bootstrap the
 reduced form and divide by the point-estimate first-stage coefficients.

--- a/stata/rddsga.ado
+++ b/stata/rddsga.ado
@@ -1,4 +1,4 @@
-*! 1.2.2 Alvaro Carril 2026-05-26
+*! 1.3.0 Alvaro Carril 2026-05-26
 program define rddsga
   version 11.1
   di as error "rddsga is removed. Use {cmd:wsga rdd} instead."

--- a/stata/rddsga.pkg
+++ b/stata/rddsga.pkg
@@ -1,4 +1,4 @@
-v 1.2.2
+v 1.3.0
 d 'RDDSGA': Deprecated alias for the wsga package
 d
 d  rddsga is the previous name of the wsga (Weighted Subgroup Analysis)

--- a/stata/rddsga.sthlp
+++ b/stata/rddsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.2 2026-05-26}{...}
+{* *! version 1.3.0 2026-05-26}{...}
 {title:Title}
 
 {pstd}

--- a/stata/stata.toc
+++ b/stata/stata.toc
@@ -1,4 +1,4 @@
-v 1.2.2
+v 1.3.0
 d Alvaro Carril
 p wsga Weighted subgroup analysis (RD designs; sharp DiD planned)
 p rddsga (deprecated alias of wsga; installs the same files)

--- a/stata/tests/smoke_did_wild.do
+++ b/stata/tests/smoke_did_wild.do
@@ -1,4 +1,4 @@
-// smoke_did_wild.do — tests for `wsga did, wildcluster`
+// smoke_did_wild.do -- tests for `wsga did, wildcluster`
 // Run from rddsga-repo/:
 //   stata-mp -b do stata/tests/smoke_did_wild.do && cat smoke_did_wild.log
 
@@ -7,7 +7,7 @@ use stata/wsga_did_synth, clear
 
 local n_fail = 0
 
-// ── TEST 1: wildcluster runs and posts non-trivial inference ─────────────────
+// -- TEST 1: wildcluster runs and posts non-trivial inference -----------------
 capture wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
   bsreps(50) seed(1) noipsw wildcluster
 if _rc != 0 {
@@ -23,7 +23,7 @@ else {
     di "  boot_type = " e(boot_type)
 }
 
-// ── TEST 2: boot_type ereturn is "wild" ──────────────────────────────────────
+// -- TEST 2: boot_type ereturn is "wild" --------------------------------------
 wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
   bsreps(20) seed(7) noipsw wildcluster
 if "`e(boot_type)'" == "wild" {
@@ -34,7 +34,7 @@ else {
     local ++n_fail
 }
 
-// ── TEST 3: pairs path still tags boot_type = "pairs" ────────────────────────
+// -- TEST 3: pairs path still tags boot_type = "pairs" ------------------------
 wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
   bsreps(20) seed(7) noipsw
 if "`e(boot_type)'" == "pairs" {
@@ -45,7 +45,7 @@ else {
     local ++n_fail
 }
 
-// ── TEST 4: seed makes wildcluster reproducible ──────────────────────────────
+// -- TEST 4: seed makes wildcluster reproducible ------------------------------
 wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
   bsreps(30) seed(42) noipsw wildcluster
 scalar _se0_run1   = e(se_g0)
@@ -64,7 +64,7 @@ else {
     local ++n_fail
 }
 
-// ── TEST 5: wildcluster + nobootstrap errors ─────────────────────────────────
+// -- TEST 5: wildcluster + nobootstrap errors ---------------------------------
 capture wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
   nobootstrap wildcluster
 if _rc != 0 {
@@ -75,7 +75,7 @@ else {
     local ++n_fail
 }
 
-// ── TEST 6: WCB SE in same order of magnitude as analytical cluster SE ───────
+// -- TEST 6: WCB SE in same order of magnitude as analytical cluster SE -------
 // On the bundled DiD synth (500 units, plenty of clusters), wild SE and
 // analytical cluster-robust SE should be within a factor of 3.
 wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) noipsw nobootstrap
@@ -104,4 +104,69 @@ if `n_fail' == 0 {
 else {
     di as error _newline "`n_fail' wildcluster smoke test(s) FAILED."
     exit 1
+}
+
+// -- WCB-R tests --
+local n_fail_r = 0
+
+// TEST: wcbrestricted runs and reports boot_type=wild_restricted
+capture wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
+  noipsw bsreps(20) seed(1) wcbrestricted
+if _rc != 0 {
+  di as error "FAIL [wcbrestricted DiD: runs]: rc=" _rc
+  local ++n_fail_r
+}
+else if "`e(boot_type)'" == "wild_restricted" {
+  di as result "PASS [wcbrestricted DiD: boot_type=wild_restricted]"
+}
+else {
+  di as error "FAIL [wcbrestricted DiD: boot_type=`e(boot_type)']"
+  local ++n_fail_r
+}
+
+// TEST: wcbrestricted seed makes results reproducible
+wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
+  noipsw bsreps(20) seed(42) wcbrestricted
+scalar _p0_r1 = e(p_g0)
+scalar _ci_r1 = e(ci_lb_g0)
+wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
+  noipsw bsreps(20) seed(42) wcbrestricted
+scalar _p0_r2 = e(p_g0)
+scalar _ci_r2 = e(ci_lb_g0)
+if abs(_p0_r1 - _p0_r2) < 1e-10 & abs(_ci_r1 - _ci_r2) < 1e-10 {
+  di as result "PASS [wcbrestricted DiD: seed reproducible]"
+}
+else {
+  di as error "FAIL [wcbrestricted DiD: seed reproducibility broken]"
+  local ++n_fail_r
+}
+
+// TEST: wcbrestricted + nobootstrap rejected
+capture wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
+  noipsw nobootstrap wcbrestricted
+if _rc != 0 {
+  di as result "PASS [wcbrestricted DiD: nobootstrap rejected, rc=" _rc "]"
+}
+else {
+  di as error "FAIL [wcbrestricted DiD: nobootstrap should have errored]"
+  local ++n_fail_r
+}
+
+// TEST: wcbrestricted + wildcluster mutually exclusive
+capture wsga did y m, sgroup(sgroup) unit(unit) time(time) treat(D) ///
+  noipsw bsreps(10) seed(1) wildcluster wcbrestricted
+if _rc != 0 {
+  di as result "PASS [wcbrestricted+wildcluster DiD: mutually exclusive, rc=" _rc "]"
+}
+else {
+  di as error "FAIL [wcbrestricted+wildcluster DiD: should have errored]"
+  local ++n_fail_r
+}
+
+if `n_fail_r' == 0 {
+  di as result _newline "All wcbrestricted DiD smoke tests passed."
+}
+else {
+  di as error _newline "`n_fail_r' wcbrestricted DiD smoke test(s) FAILED."
+  exit 1
 }

--- a/stata/tests/smoke_rdd_wild.do
+++ b/stata/tests/smoke_rdd_wild.do
@@ -161,3 +161,80 @@ else {
   di as error _newline "`n_fail' smoke test(s) FAILED."
   exit 1
 }
+
+// -- TEST 11: wcbrestricted runs and posts boot_type=wild_restricted --
+capture wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(30) seed(1) noipsw cluster(clust) wcbrestricted
+if _rc != 0 {
+  di as error "FAIL [wcbrestricted: runs]: rc=" _rc
+  local ++n_fail
+}
+else if "`e(boot_type)'" == "wild_restricted" & e(N_clust) == 50 {
+  di as result "PASS [wcbrestricted: boot_type=wild_restricted, N_clust=50]"
+}
+else {
+  di as error "FAIL [wcbrestricted: boot_type=`e(boot_type)', N_clust=" e(N_clust) "]"
+  local ++n_fail
+}
+
+// -- TEST 12: wcbrestricted without cluster() rejected --
+capture wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(20) seed(1) noipsw wcbrestricted
+if _rc != 0 {
+  di as result "PASS [wcbrestricted-without-cluster rejected, rc=" _rc "]"
+}
+else {
+  di as error "FAIL [wcbrestricted-without-cluster should have errored]"
+  local ++n_fail
+}
+
+// -- TEST 13: wcbrestricted + nobootstrap rejected --
+capture wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  noipsw cluster(clust) wcbrestricted nobootstrap
+if _rc != 0 {
+  di as result "PASS [wcbrestricted+nobootstrap rejected, rc=" _rc "]"
+}
+else {
+  di as error "FAIL [wcbrestricted+nobootstrap should have errored]"
+  local ++n_fail
+}
+
+// -- TEST 14: wildcluster + wcbrestricted mutually exclusive --
+capture wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(10) seed(1) noipsw cluster(clust) wildcluster wcbrestricted
+if _rc != 0 {
+  di as result "PASS [wildcluster+wcbrestricted mutually exclusive, rc=" _rc "]"
+}
+else {
+  di as error "FAIL [wildcluster+wcbrestricted should have errored]"
+  local ++n_fail
+}
+
+// -- TEST 15: wcbrestricted seed makes results reproducible --
+wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(30) seed(42) noipsw cluster(clust) wcbrestricted
+scalar _p0_run1 = e(p_g0)
+scalar _ci_run1 = e(ci_lb_g0)
+
+wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
+  bsreps(30) seed(42) noipsw cluster(clust) wcbrestricted
+scalar _p0_run2 = e(p_g0)
+scalar _ci_run2 = e(ci_lb_g0)
+
+if abs(_p0_run1 - _p0_run2) < 1e-10 & abs(_ci_run1 - _ci_run2) < 1e-10 {
+  di as result "PASS [wcbrestricted seed: p-val and CI reproducible]"
+}
+else {
+  di as error "FAIL [wcbrestricted seed reproducibility broken]"
+  di "  p0 diff: " abs(_p0_run1 - _p0_run2)
+  di "  ci diff: " abs(_ci_run1 - _ci_run2)
+  local ++n_fail
+}
+
+if `n_fail' == 0 {
+  di as result _newline "All wsga rdd wildcluster smoke tests passed."
+}
+else {
+  di as error _newline "`n_fail' smoke test(s) FAILED."
+  exit 1
+}

--- a/stata/tests/smoke_rdd_wild.do
+++ b/stata/tests/smoke_rdd_wild.do
@@ -1,4 +1,4 @@
-// smoke_rdd_wild.do -- tests for `wsga rdd, cluster() wildcluster`
+// smoke_rdd_wild.do -- tests for `wsga rdd, cluster() wildcluster / wcbrestricted`
 // Run from rddsga-repo/:
 //   stata-mp -b do stata/tests/smoke_rdd_wild.do && cat smoke_rdd_wild.log
 
@@ -109,7 +109,7 @@ else {
   local ++n_fail
 }
 
-// -- TEST 8: G<30 advisory fires for pairs but not for wild (just runs without error) --
+// -- TEST 8: G<30 advisory fires for pairs but not for wild --
 preserve
 gen clust_small = ceil(_n/1000)
 qui wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
@@ -153,14 +153,6 @@ else {
   local ++n_fail
 }
 restore
-
-if `n_fail' == 0 {
-  di as result _newline "All wsga rdd wildcluster smoke tests passed."
-}
-else {
-  di as error _newline "`n_fail' smoke test(s) FAILED."
-  exit 1
-}
 
 // -- TEST 11: wcbrestricted runs and posts boot_type=wild_restricted --
 capture wsga rdd Y, sgroup(G) running(X) bwidth(10) reducedform ///
@@ -231,6 +223,7 @@ else {
   local ++n_fail
 }
 
+// -- Final result --
 if `n_fail' == 0 {
   di as result _newline "All wsga rdd wildcluster smoke tests passed."
 }

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,4 +1,4 @@
-*! 1.2.2 Alvaro Carril 2026-05-26
+*! 1.3.0 Alvaro Carril 2026-05-26
 
 // -- Dispatcher ----------------------------------------------------------------
 program define wsga
@@ -28,7 +28,7 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     BALance(varlist numeric) DIBALance probit ///
     IVregress REDUCEDform FIRSTstage vce(string) p(int 1) m(int 2) rbalance(int 0) ///
     noBOOTstrap bsreps(real 200) FIXEDbootstrap FIXEDps BLOCKbootstrap(string) NORMal noipsw weights(string) ///
-    CLuster(varname) WILDcluster ///
+    CLuster(varname) WILDcluster WCBRestricted ///
     Seed(string) ]
 
 // --- Validate required options ------------------------------------------------
@@ -58,6 +58,30 @@ if "`wildcluster'" != "" & "`ivregress'" != "" {
 if "`wildcluster'" != "" & "`blockbootstrap'" != "" {
   di as text ///
 "Note: {bf:blockbootstrap} is ignored under {bf:wildcluster} (Rademacher signs are drawn unstratified)."
+}
+if "`wcbrestricted'" != "" & "`bootstrap'" == "nobootstrap" {
+  di as error ///
+"option {bf:wcbrestricted} requires the bootstrap loop; cannot be combined with {bf:nobootstrap}."
+  exit 198
+}
+if "`wcbrestricted'" != "" & "`cluster'" == "" {
+  di as error ///
+"option {bf:wcbrestricted} requires {bf:cluster(varname)}; no natural default for RDD."
+  exit 198
+}
+if "`wcbrestricted'" != "" & "`ivregress'" != "" {
+  di as error ///
+"option {bf:wcbrestricted} is not supported with {bf:ivregress} (fuzzy RD via 2SLS)."
+  exit 198
+}
+if "`wcbrestricted'" != "" & "`wildcluster'" != "" {
+  di as error ///
+"options {bf:wildcluster} and {bf:wcbrestricted} are mutually exclusive."
+  exit 198
+}
+if "`wcbrestricted'" != "" & "`blockbootstrap'" != "" {
+  di as text ///
+"Note: {bf:blockbootstrap} is ignored under {bf:wcbrestricted} (Rademacher signs are drawn unstratified)."
 }
 // ------------------------------------------------------------------------------
 
@@ -359,7 +383,8 @@ if "`ipsw'" != "noipsw" & `: list sizeof balance' > 0 {
 }
 if "`seed'" != "" local psw_boot_opts `psw_boot_opts' seed(`seed')
 if "`cluster'" != "" local psw_boot_opts `psw_boot_opts' cluster(`cluster')
-if "`wildcluster'" != "" local psw_boot_opts `psw_boot_opts' wildcluster
+if "`wildcluster'"   != "" local psw_boot_opts `psw_boot_opts' wildcluster
+if "`wcbrestricted'" != "" local psw_boot_opts `psw_boot_opts' wcbrestricted
 
 // Cluster validation + G < 30 advisory when clustering is active
 if "`cluster'" != "" & "`bootstrap'" != "nobootstrap" {
@@ -373,9 +398,13 @@ if "`cluster'" != "" & "`bootstrap'" != "nobootstrap" {
   }
   qui levelsof `cluster' if `touse' & `bwidth', local(_clusters)
   local _N_clust : word count `_clusters'
-  if `_N_clust' < 30 & "`wildcluster'" == "" {
+  if `_N_clust' < 30 & "`wildcluster'" == "" & "`wcbrestricted'" == "" {
     di as text ///
 "Note: pairs-cluster bootstrap with " as result %4.0f `_N_clust' as text " clusters.  With fewer than ~30 clusters, pairs over-rejects under H0; consider the {bf:wildcluster} option for better size control (Cameron, Gelbach & Miller 2008)."
+  }
+  if `_N_clust' < 12 & "`wildcluster'" != "" {
+    di as text ///
+"Note: WCB-U with " as result %4.0f `_N_clust' as text " clusters.  With fewer than ~12 clusters, the restricted variant has better size control; consider {bf:wcbrestricted} (MacKinnon & Webb 2017)."
   }
 }
 
@@ -754,7 +783,7 @@ program define _wsga_rdd_myboo, eclass
   syntax anything [, PSW IPSWeight(name) KERNELipsw(name) KWT(name) ///
     TOuse(name) BWIDTH(string) BALance(varlist) OWeights(name) ///
     M(integer 2) BINarymodel(string) PSCore(name) COmsup Seed(string) ///
-    CLuster(varname) WILDcluster]
+    CLuster(varname) WILDcluster WCBRestricted]
 
   local svar : word 1 of `anything'
   local cvar : word 2 of `anything'
@@ -788,7 +817,7 @@ program define _wsga_rdd_myboo, eclass
   //      data; does not propagate IPW uncertainty -- intentional, CGM 2008).
   local _saved_cmdline = e(cmdline)
   local _saved_depvar  = e(depvar)
-  if "`wildcluster'" != "" {
+  if "`wildcluster'" != "" | "`wcbrestricted'" != "" {
     tempvar _wsga_xb _wsga_resid
     qui predict double `_wsga_xb'    if `esample', xb
     qui predict double `_wsga_resid' if `esample', residuals
@@ -797,28 +826,108 @@ program define _wsga_rdd_myboo, eclass
     // Cmdline shape after `regress' is: "<cmd> <depvar> <rhs ...>".
     gettoken _wsga_cmd_name _wsga_cmd_rest : _saved_cmdline
     gettoken _wsga_olddep   _wsga_cmd_rhs  : _wsga_cmd_rest
+
+    if "`wcbrestricted'" != "" {
+      // WCB-R: fit three restricted models before the loop to obtain
+      // restricted xb and residuals for each null hypothesis.
+      // The cmdline treatment term "i.svar#1.cvar" is substituted to impose
+      // each restriction; the unrestricted model is refit inside the loop.
+      local _rhs_r0    = subinstr("`_wsga_cmd_rhs'", ///
+        "i.`svar'#1.`cvar'", "1.`svar'#1.`cvar'", 1)   // H0: G0_Z=0
+      local _rhs_r1    = subinstr("`_wsga_cmd_rhs'", ///
+        "i.`svar'#1.`cvar'", "0.`svar'#1.`cvar'", 1)   // H0: G1_Z=0
+      local _rhs_rdiff = subinstr("`_wsga_cmd_rhs'", ///
+        "i.`svar'#1.`cvar'", "1.`cvar'", 1)             // H0: G0_Z=G1_Z
+
+      tempvar _wsga_xb_r0 _wsga_resid_r0 ///
+              _wsga_xb_r1 _wsga_resid_r1 ///
+              _wsga_xb_rdiff _wsga_resid_rdiff
+
+      qui `_wsga_cmd_name' `_wsga_olddep' `_rhs_r0'
+      qui predict double `_wsga_xb_r0'    if `esample', xb
+      qui predict double `_wsga_resid_r0' if `esample', residuals
+
+      qui `_wsga_cmd_name' `_wsga_olddep' `_rhs_r1'
+      qui predict double `_wsga_xb_r1'    if `esample', xb
+      qui predict double `_wsga_resid_r1' if `esample', residuals
+
+      qui `_wsga_cmd_name' `_wsga_olddep' `_rhs_rdiff'
+      qui predict double `_wsga_xb_rdiff'    if `esample', xb
+      qui predict double `_wsga_resid_rdiff' if `esample', residuals
+
+      // Restore the unrestricted fit so e(b) etc. are correct for the loop
+      qui `_wsga_cmd_name' `_wsga_olddep' `_wsga_cmd_rhs'
+
+      // Running p-value counters for restricted draws
+      scalar _wcbr_count_g0    = 0
+      scalar _wcbr_count_g1    = 0
+      scalar _wcbr_count_diff  = 0
+      scalar _wcbr_B_g0        = 0
+      scalar _wcbr_B_g1        = 0
+      scalar _wcbr_B_diff      = 0
+    }
   }
 
   // Start bootstrap
   di ""
-  local _boot_title = cond("`wildcluster'" != "", "Wild cluster bootstrap", ///
-                        cond("`cluster'" != "", "Cluster bootstrap", "Bootstrap replications"))
+  local _boot_title = cond("`wcbrestricted'" != "", "Wild cluster bootstrap (WCB-R)", ///
+                        cond("`wildcluster'" != "", "Wild cluster bootstrap (WCB-U)", ///
+                          cond("`cluster'" != "", "Cluster bootstrap", "Bootstrap replications")))
   _dots 0, title(`_boot_title') reps(`B')
   cap mat drop cumulative
   if "`seed'" != "" set seed `seed'
   tempvar COMSUP_b
   forvalues i=1/`B' {
     preserve
-    if "`wildcluster'" != "" {
-      // WCB-U: draw one Rademacher sign per cluster, broadcast to rows,
-      // y_star = xb + sign * resid; refit `<cmd> y_star <rhs>` (#37: never
-      // touch the user's outcome variable).
+    if "`wildcluster'" != "" | "`wcbrestricted'" != "" {
+      // Draw one Rademacher sign per cluster, broadcast to rows.
       tempvar _wsga_u _wsga_sign _wsga_ystar
       qui by `cluster', sort: gen double `_wsga_u' = runiform() if _n == 1
       qui by `cluster': replace `_wsga_u' = `_wsga_u'[1]
-      qui gen double `_wsga_sign'  = cond(`_wsga_u' < 0.5, -1, 1) if `esample'
+      qui gen double `_wsga_sign' = cond(`_wsga_u' < 0.5, -1, 1) if `esample'
+
+      // Unrestricted y_star -> CI / SE draw (same for WCB-U and WCB-R)
       qui gen double `_wsga_ystar' = `_wsga_xb' + `_wsga_sign' * `_wsga_resid' if `esample'
       qui `_wsga_cmd_name' `_wsga_ystar' `_wsga_cmd_rhs'
+      // Coefficient extraction happens below (shared with pairs path)
+
+      if "`wcbrestricted'" != "" {
+        // Three restricted refits on unrestricted model; p-value counters updated.
+        // P-value formula: (1 + #{|draw| >= |est|}) / (B+1) -- no recentering,
+        // because restricted draws are centred at 0 under H0 by construction
+        // (MacKinnon & Webb 2017, eq. 8).
+        tempvar _wsga_ys_r0 _wsga_ys_r1 _wsga_ys_rdiff
+        qui gen double `_wsga_ys_r0' = ///
+          `_wsga_xb_r0' + `_wsga_sign' * `_wsga_resid_r0' if `esample'
+        capture qui `_wsga_cmd_name' `_wsga_ys_r0' `_wsga_cmd_rhs'
+        if !_rc {
+          scalar _wcbr_draw_g0 = _b[0.`svar'#1.`cvar']
+          if abs(_wcbr_draw_g0) >= abs(b[1,1]) ///
+            scalar _wcbr_count_g0 = _wcbr_count_g0 + 1
+          scalar _wcbr_B_g0 = _wcbr_B_g0 + 1
+        }
+
+        qui gen double `_wsga_ys_r1' = ///
+          `_wsga_xb_r1' + `_wsga_sign' * `_wsga_resid_r1' if `esample'
+        capture qui `_wsga_cmd_name' `_wsga_ys_r1' `_wsga_cmd_rhs'
+        if !_rc {
+          scalar _wcbr_draw_g1 = _b[1.`svar'#1.`cvar']
+          if abs(_wcbr_draw_g1) >= abs(b[1,2]) ///
+            scalar _wcbr_count_g1 = _wcbr_count_g1 + 1
+          scalar _wcbr_B_g1 = _wcbr_B_g1 + 1
+        }
+
+        qui gen double `_wsga_ys_rdiff' = ///
+          `_wsga_xb_rdiff' + `_wsga_sign' * `_wsga_resid_rdiff' if `esample'
+        capture qui `_wsga_cmd_name' `_wsga_ys_rdiff' `_wsga_cmd_rhs'
+        if !_rc {
+          scalar _wcbr_draw_diff = _b[1.`svar'#1.`cvar'] - _b[0.`svar'#1.`cvar']
+          scalar _orig_diff = b[1,2] - b[1,1]
+          if abs(_wcbr_draw_diff) >= abs(_orig_diff) ///
+            scalar _wcbr_count_diff = _wcbr_count_diff + 1
+          scalar _wcbr_B_diff = _wcbr_B_diff + 1
+        }
+      }
       // Skip PS refit block below; jump to coefficient extraction
     }
     else {
@@ -935,28 +1044,36 @@ program define _wsga_rdd_myboo, eclass
     ereturn scalar N_clust = `_N_clust'
     ereturn local clustvar `cluster'
   }
-  ereturn local boot_type = cond("`wildcluster'" != "", "wild", "pairs")
-  // Empirical p-values for subgroups
-  // Recentered: count draws where |draw - est| >= |est|, testing H0: coef=0
-  cap scalar drop bscoef
-  forvalues g = 0/1 {
-    local count = 0
-    forvalues i = 1/`B' {
-      scalar bscoef = cumulative[`i',`=`g'+1']
-      if abs(bscoef - b[1,`=`g'+1']) >= abs(b[1,`=`g'+1']) local count = `count'+1
+  ereturn local boot_type = cond("`wcbrestricted'" != "", "wild_restricted", ///
+                               cond("`wildcluster'" != "", "wild", "pairs"))
+  // P-values
+  if "`wcbrestricted'" != "" {
+    // WCB-R: non-recentered formula using restricted draws
+    ereturn scalar p_g0   = (1 + _wcbr_count_g0)   / (_wcbr_B_g0   + 1)
+    ereturn scalar p_g1   = (1 + _wcbr_count_g1)   / (_wcbr_B_g1   + 1)
+    ereturn scalar p_diff = (1 + _wcbr_count_diff)  / (_wcbr_B_diff + 1)
+  }
+  else {
+    // WCB-U and pairs: recentered formula on unrestricted draws
+    cap scalar drop bscoef
+    forvalues g = 0/1 {
+      local count = 0
+      forvalues i = 1/`B' {
+        scalar bscoef = cumulative[`i',`=`g'+1']
+        if abs(bscoef - b[1,`=`g'+1']) >= abs(b[1,`=`g'+1']) local count = `count'+1
+      }
+      scalar pval`g' = (1+`count') / (`B' + 1)
+      ereturn scalar p_g`g' = pval`g'
     }
-    scalar pval`g' = (1+`count') / (`B' + 1)
-    ereturn scalar p_g`g' = pval`g'
+    scalar orig_diff = b[1,2] - b[1,1]
+    local count_diff = 0
+    forvalues i = 1/`B' {
+      scalar bscoef = cumulative[`i',3]
+      if abs(bscoef - orig_diff) >= abs(orig_diff) local count_diff = `count_diff' + 1
+    }
+    scalar pval_diff = (1 + `count_diff') / (`B' + 1)
+    ereturn scalar p_diff = pval_diff
   }
-  // Empirical p-value for diff (column 3)
-  scalar orig_diff = b[1,2] - b[1,1]
-  local count_diff = 0
-  forvalues i = 1/`B' {
-    scalar bscoef = cumulative[`i',3]
-    if abs(bscoef - orig_diff) >= abs(orig_diff) local count_diff = `count_diff' + 1
-  }
-  scalar pval_diff = (1 + `count_diff') / (`B' + 1)
-  ereturn scalar p_diff = pval_diff
   // Empirical confidence intervals
   svmat cumulative, names(_subgroup)
   forvalues g = 0/1 {
@@ -1258,22 +1375,36 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     IPSWeight(name) PSCore(name) comsup ///
     vce(string) m(int 2) ///
     noBOOTstrap bsreps(real 200) FIXEDbootstrap FIXEDps BLOCKbootstrap(string) ///
-    WILDcluster ///
+    WILDcluster WCBRestricted ///
     NORMal noipsw weights(string) Seed(string) ]
 
   // -- Sample mask
   marksample touse, novarlist
   markout `touse' `unit' `time' `treat' `sgroup'
 
-  // -- wildcluster validation: requires the bootstrap loop (it IS the loop).
+  // -- wildcluster / wcbrestricted validation
   if "`wildcluster'" != "" & "`bootstrap'" == "nobootstrap" {
     di as error ///
 "option {bf:wildcluster} requires the bootstrap loop; cannot be combined with {bf:nobootstrap}."
     exit 198
   }
+  if "`wcbrestricted'" != "" & "`bootstrap'" == "nobootstrap" {
+    di as error ///
+"option {bf:wcbrestricted} requires the bootstrap loop; cannot be combined with {bf:nobootstrap}."
+    exit 198
+  }
+  if "`wcbrestricted'" != "" & "`wildcluster'" != "" {
+    di as error ///
+"options {bf:wildcluster} and {bf:wcbrestricted} are mutually exclusive."
+    exit 198
+  }
   if "`wildcluster'" != "" & "`blockbootstrap'" != "" {
     di as text ///
 "Note: {bf:blockbootstrap} is ignored under {bf:wildcluster} (Rademacher signs are drawn unstratified)."
+  }
+  if "`wcbrestricted'" != "" & "`blockbootstrap'" != "" {
+    di as text ///
+"Note: {bf:blockbootstrap} is ignored under {bf:wcbrestricted} (Rademacher signs are drawn unstratified)."
   }
 
   // -- Outcome and covariates
@@ -1468,17 +1599,55 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
   if use_bootstrap {
     qui levelsof `unit' if `touse', local(_clusters)
     scalar N_clust = `: word count `_clusters''
-    if N_clust < 30 & "`wildcluster'" == "" {
+    if N_clust < 30 & "`wildcluster'" == "" & "`wcbrestricted'" == "" {
       di as text ///
 "Note: pairs-cluster bootstrap with " as result %4.0f N_clust as text " clusters.  With fewer than ~30 clusters, pairs over-rejects under H0; consider the {bf:wildcluster} option for better size control (Cameron, Gelbach & Miller 2008)."
     }
+    if N_clust < 12 & "`wildcluster'" != "" {
+      di as text ///
+"Note: WCB-U with " as result %4.0f N_clust as text " clusters.  With fewer than ~12 clusters, the restricted variant has better size control; consider {bf:wcbrestricted} (MacKinnon & Webb 2017)."
+    }
 
-    if "`wildcluster'" != "" {
-      // Store fitted values (X*beta + unit FE) and idiosyncratic residuals
-      // BEFORE saving the tempfile so they survive the per-rep reload.
+    if "`wildcluster'" != "" | "`wcbrestricted'" != "" {
+      // Store unrestricted fitted values and idiosyncratic residuals.
       tempvar _wsga_yhat _wsga_e_hat
       qui predict double `_wsga_yhat'  if `_did_esample', xbu
       qui predict double `_wsga_e_hat' if `_did_esample', e
+
+      if "`wcbrestricted'" != "" {
+        // WCB-R: fit three restricted models and store their xbu/e.
+        tempvar _wsga_Z_pooled
+        qui gen byte `_wsga_Z_pooled' = `G0_Z' + `G1_Z'
+
+        tempvar _wsga_yhat_r0 _wsga_e_r0
+        qui xtreg `depvar' `G1_Z' `G0_post' `G1_post' `g0_covs' `g1_covs' ///
+          [pw=`ipsweight'] if `touse' & `ipsweight' > 0, fe vce(cluster `unit')
+        qui predict double `_wsga_yhat_r0' if `_did_esample', xbu
+        qui predict double `_wsga_e_r0'    if `_did_esample', e
+
+        tempvar _wsga_yhat_r1 _wsga_e_r1
+        qui xtreg `depvar' `G0_Z' `G0_post' `G1_post' `g0_covs' `g1_covs' ///
+          [pw=`ipsweight'] if `touse' & `ipsweight' > 0, fe vce(cluster `unit')
+        qui predict double `_wsga_yhat_r1' if `_did_esample', xbu
+        qui predict double `_wsga_e_r1'    if `_did_esample', e
+
+        tempvar _wsga_yhat_rdiff _wsga_e_rdiff
+        qui xtreg `depvar' `_wsga_Z_pooled' `G0_post' `G1_post' `g0_covs' `g1_covs' ///
+          [pw=`ipsweight'] if `touse' & `ipsweight' > 0, fe vce(cluster `unit')
+        qui predict double `_wsga_yhat_rdiff' if `_did_esample', xbu
+        qui predict double `_wsga_e_rdiff'    if `_did_esample', e
+
+        // Restore unrestricted fit
+        qui xtreg `depvar' `rhs' [pw=`ipsweight'] ///
+          if `touse' & `ipsweight' > 0, fe vce(cluster `unit')
+
+        scalar _wcbr_cnt_g0   = 0
+        scalar _wcbr_cnt_g1   = 0
+        scalar _wcbr_cnt_diff = 0
+        scalar _wcbr_B_g0     = 0
+        scalar _wcbr_B_g1     = 0
+        scalar _wcbr_B_diff   = 0
+      }
     }
 
     tempfile _wsga_did_panel
@@ -1487,8 +1656,11 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     tempname _wsga_did_draws
     matrix `_wsga_did_draws' = J(`bsreps', 2, .)
 
-    if "`wildcluster'" != "" {
-      display as text "Wild cluster bootstrap (`bsreps' reps):"
+    if "`wcbrestricted'" != "" {
+      display as text "Wild cluster bootstrap WCB-R (`bsreps' reps):"
+    }
+    else if "`wildcluster'" != "" {
+      display as text "Wild cluster bootstrap WCB-U (`bsreps' reps):"
     }
     else {
       display as text "Cluster bootstrap (`bsreps' reps):"
@@ -1497,20 +1669,55 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
     forvalues _b = 1/`bsreps' {
       qui use `_wsga_did_panel', clear
       capture {
-        if "`wildcluster'" != "" {
-          // --- WCB-U: Rademacher signs, one per unit, broadcast to all rows.
+        if "`wildcluster'" != "" | "`wcbrestricted'" != "" {
+          // Draw one Rademacher sign per unit, broadcast to all rows.
           tempvar _wsga_u _wsga_sign _wsga_ystar
           qui by `unit', sort: gen double `_wsga_u' = runiform() if _n == 1
           qui by `unit': replace `_wsga_u' = `_wsga_u'[1]
           qui gen double `_wsga_sign' = cond(`_wsga_u' < 0.5, -1, 1)
-          qui gen double `_wsga_ystar' = `_wsga_yhat' + `_wsga_sign' * `_wsga_e_hat'
 
-          // Refit on bootstrap outcome; weights and X fixed at original values.
+          // Unrestricted y_star -> CI/SE draw
+          qui gen double `_wsga_ystar' = `_wsga_yhat' + `_wsga_sign' * `_wsga_e_hat'
           qui xtreg `_wsga_ystar' `rhs' [pw=`ipsweight'] ///
             if `_did_esample' & `ipsweight' > 0, fe vce(cluster `unit')
           matrix `_wsga_did_draws'[`_b', 1] = _b[`G0_Z']
           matrix `_wsga_did_draws'[`_b', 2] = _b[`G1_Z']
           scalar B_ok = B_ok + 1
+
+          if "`wcbrestricted'" != "" {
+            // Three restricted refits for p-values (non-recentered formula).
+            tempvar _wsga_ys_r0 _wsga_ys_r1 _wsga_ys_rdiff
+
+            qui gen double `_wsga_ys_r0' = ///
+              `_wsga_yhat_r0' + `_wsga_sign' * `_wsga_e_r0'
+            capture qui xtreg `_wsga_ys_r0' `rhs' [pw=`ipsweight'] ///
+              if `_did_esample' & `ipsweight' > 0, fe vce(cluster `unit')
+            if !_rc {
+              scalar _wcbr_d_g0 = _b[`G0_Z']
+              if abs(_wcbr_d_g0) >= abs(b_g0) scalar _wcbr_cnt_g0 = _wcbr_cnt_g0 + 1
+              scalar _wcbr_B_g0 = _wcbr_B_g0 + 1
+            }
+
+            qui gen double `_wsga_ys_r1' = ///
+              `_wsga_yhat_r1' + `_wsga_sign' * `_wsga_e_r1'
+            capture qui xtreg `_wsga_ys_r1' `rhs' [pw=`ipsweight'] ///
+              if `_did_esample' & `ipsweight' > 0, fe vce(cluster `unit')
+            if !_rc {
+              scalar _wcbr_d_g1 = _b[`G1_Z']
+              if abs(_wcbr_d_g1) >= abs(b_g1) scalar _wcbr_cnt_g1 = _wcbr_cnt_g1 + 1
+              scalar _wcbr_B_g1 = _wcbr_B_g1 + 1
+            }
+
+            qui gen double `_wsga_ys_rdiff' = ///
+              `_wsga_yhat_rdiff' + `_wsga_sign' * `_wsga_e_rdiff'
+            capture qui xtreg `_wsga_ys_rdiff' `rhs' [pw=`ipsweight'] ///
+              if `_did_esample' & `ipsweight' > 0, fe vce(cluster `unit')
+            if !_rc {
+              scalar _wcbr_d_diff = _b[`G1_Z'] - _b[`G0_Z']
+              if abs(_wcbr_d_diff) >= abs(b_diff) scalar _wcbr_cnt_diff = _wcbr_cnt_diff + 1
+              scalar _wcbr_B_diff = _wcbr_B_diff + 1
+            }
+          }
         }
         else {
         if "`blockbootstrap'" != "" {
@@ -1633,12 +1840,20 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
       scalar ci_lb_diff  = r(r1)
       scalar ci_ub_diff  = r(r2)
 
-      qui count if abs(_draw1    - b_g0)   >= abs(b_g0)
-      scalar p_g0    = (1 + r(N)) / (B_ok + 1)
-      qui count if abs(_draw2    - b_g1)   >= abs(b_g1)
-      scalar p_g1    = (1 + r(N)) / (B_ok + 1)
-      qui count if abs(_drawdiff - b_diff) >= abs(b_diff)
-      scalar p_diff  = (1 + r(N)) / (B_ok + 1)
+      if "`wcbrestricted'" != "" {
+        // WCB-R: non-recentered formula from restricted draws
+        scalar p_g0   = (1 + _wcbr_cnt_g0)   / (_wcbr_B_g0   + 1)
+        scalar p_g1   = (1 + _wcbr_cnt_g1)   / (_wcbr_B_g1   + 1)
+        scalar p_diff = (1 + _wcbr_cnt_diff)  / (_wcbr_B_diff + 1)
+      }
+      else {
+        qui count if abs(_draw1    - b_g0)   >= abs(b_g0)
+        scalar p_g0    = (1 + r(N)) / (B_ok + 1)
+        qui count if abs(_draw2    - b_g1)   >= abs(b_g1)
+        scalar p_g1    = (1 + r(N)) / (B_ok + 1)
+        qui count if abs(_drawdiff - b_diff) >= abs(b_diff)
+        scalar p_diff  = (1 + r(N)) / (B_ok + 1)
+      }
     }
     restore
   }
@@ -1689,7 +1904,9 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
   di as text "N (G=0): " as result %4.0f N_G0 ///
      as text "   N (G=1): " as result %4.0f N_G1
   if use_bootstrap {
-    local _boot_label = cond("`wildcluster'" != "", "Wild cluster bootstrap", "Cluster bootstrap")
+    local _boot_label = cond("`wcbrestricted'" != "", "Wild cluster bootstrap (WCB-R)", ///
+                          cond("`wildcluster'" != "", "Wild cluster bootstrap (WCB-U)", ///
+                            "Cluster bootstrap"))
     di as text "`_boot_label': " as result %4.0f B_ok ///
        as text " / " as result `bsreps' ///
        as text " reps, clustered on '" as result "`unit'" ///
@@ -1788,7 +2005,8 @@ syntax varlist(min=1 numeric fv) [if] [in], ///
   if use_bootstrap {
     ereturn scalar B_ok    = B_ok
     ereturn scalar N_clust = N_clust
-    ereturn local boot_type = cond("`wildcluster'" != "", "wild", "pairs")
+    ereturn local boot_type = cond("`wcbrestricted'" != "", "wild_restricted", ///
+                               cond("`wildcluster'" != "", "wild", "pairs"))
   }
 end
 

--- a/stata/wsga.pkg
+++ b/stata/wsga.pkg
@@ -1,4 +1,4 @@
-v 1.2.2
+v 1.3.0
 d 'WSGA': Weighted subgroup analysis
 d
 d  wsga conducts weighted subgroup analysis for research designs that

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.2 2026-05-26}{...}
+{* *! version 1.3.0 2026-05-26}{...}
 {title:Title}
 
 {pstd}

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.2 2026-05-26}{...}
+{* *! version 1.3.0 2026-05-26}{...}
 {viewerjumpto "Stored results" "wsga_did##results"}{...}
 {title:Title}
 

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -157,7 +157,7 @@ under H0 is the binding concern at small G.{p_end}
 {synopt:{cmd:e(cmd)}}{cmd:wsga}{p_end}
 {synopt:{cmd:e(subcmd)}}{cmd:did}{p_end}
 {synopt:{cmd:e(depvar)}}name of dependent variable{p_end}
-{synopt:{cmd:e(boot_type)}}(bootstrap) {cmd:pairs} or {cmd:wild}{p_end}
+{synopt:{cmd:e(boot_type)}}(bootstrap) {cmd:pairs}, {cmd:wild}, or {cmd:wild_restricted}{p_end}
 
 {p2col 5 23 26 2: Matrices}{p_end}
 {synopt:{cmd:e(b)}}1{cmd:x}2 coefficient vector with columns named {cmd:G0_Z} and {cmd:G1_Z}{p_end}

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -43,7 +43,8 @@
 {synopt:{opt seed(#)}}RNG seed for reproducibility{p_end}
 {synopt:{opt fixedps}}hold propensity score fixed across bootstrap reps (diagnostic){p_end}
 {synopt:{opt blockbootstrap(varname)}}stratify the unit-level cluster resample by {it:varname}; must be unit-constant{p_end}
-{synopt:{opt wildcluster}}use wild cluster bootstrap (WCB-U, Rademacher signs) instead of pairs; recommended at < ~30 clusters; ignores {opt blockbootstrap} and does not refit the propensity score (so it does not propagate IPW uncertainty); see {it:Remarks}{p_end}
+{synopt:{opt wildcluster}}unrestricted wild cluster bootstrap (WCB-U, Rademacher signs); recommended at < ~30 clusters; see {it:Remarks}{p_end}
+{synopt:{opt wcbrestricted}}restricted wild cluster bootstrap (WCB-R); recommended at < ~12 clusters; see {it:Remarks}{p_end}
 {synopt:{opt weights(varname)}}pre-existing observation weights{p_end}
 {synoptline}
 
@@ -74,8 +75,11 @@ Clustering is always on {it:unit}.
 {pstd}With cluster bootstrap (pairs):{p_end}
 {phang2}{cmd:. wsga did Y M, sgroup(G) unit(id) time(t) treat(D) bsreps(200) seed(1)}{p_end}
 
-{pstd}With wild cluster bootstrap (recommended at small G):{p_end}
+{pstd}With unrestricted wild cluster bootstrap (recommended at G < ~30):{p_end}
 {phang2}{cmd:. wsga did Y M, sgroup(G) unit(id) time(t) treat(D) bsreps(200) seed(1) wildcluster}{p_end}
+
+{pstd}With restricted wild cluster bootstrap (recommended at G < ~12):{p_end}
+{phang2}{cmd:. wsga did Y M, sgroup(G) unit(id) time(t) treat(D) bsreps(200) seed(1) wcbrestricted}{p_end}
 
 
 {marker remarks}{...}
@@ -91,12 +95,29 @@ a one-time advisory is emitted.{p_end}
 
 {pstd}
 The {opt wildcluster} option requests the unrestricted wild cluster bootstrap
-(WCB-U) with Rademacher signs at the cluster level.  This conditions on the
-data (residuals from the original fit are sign-flipped at the unit level) and
-the regression is refit on the bootstrap outcome.  WCB-U gives substantially
-better size control than pairs at small G.  Caveat: because the data is held
-fixed, the propensity score is {it:not} refit per replicate, so WCB-U does not
-propagate IPW estimation uncertainty.  Use {opt wildcluster} when honest size
+(WCB-U) with Rademacher signs at the cluster level.  Residuals from the
+original (unrestricted) fit are sign-flipped at the unit level; the
+unrestricted model is refit on the resulting bootstrap outcome.  WCB-U gives
+substantially better size control than pairs at small G.  P-values use the
+recentered formula {it:(1 + #{|draw - est| >= |est|}) / (B+1)}.
+Recommended when G < ~30.{p_end}
+
+{pstd}
+The {opt wcbrestricted} option requests the restricted wild cluster bootstrap
+(WCB-R; MacKinnon and Webb 2017, 2018).  For each of the three null hypotheses
+(H0: b_G0=0, H0: b_G1=0, H0: b_G0=b_G1), the restricted model imposing that
+null is fit; its residuals are sign-flipped at the unit level; and the
+unrestricted model is refit on the resulting bootstrap outcome to obtain the
+test statistic.  Because the null is imposed in the residuals, the draws are
+centered at zero under H0, so p-values use the non-recentered formula
+{it:(1 + #{|draw| >= |est|}) / (B+1)}.  Confidence intervals remain empirical
+percentile CIs from unrestricted draws.  WCB-R has better size control than
+WCB-U at very small G (< ~12) at the cost of four model fits per replicate
+instead of one.  Recommended when G < ~12.{p_end}
+
+{pstd}
+Caveat: neither WCB variant refits the propensity score per replicate, so
+neither propagates IPW estimation uncertainty.  Use WCB when honest size
 under H0 is the binding concern at small G.{p_end}
 
 

--- a/stata/wsga_rdd.sthlp
+++ b/stata/wsga_rdd.sthlp
@@ -34,6 +34,8 @@
 {syntab:IPW}
 {synopt:{opt balance(varlist)}}moderators for propensity score; defaults to covariates{p_end}
 {synopt:{opt noipsw}}skip IPW reweighting{p_end}
+{synopt:{opt ipsweight(newvar)}}save IPW weights to {it:newvar} in the dataset{p_end}
+{synopt:{opt pscore(newvar)}}save propensity score to {it:newvar} in the dataset{p_end}
 {synopt:{opt m(#)}}weighting mode: 2 = both groups (default), 1 = G1->G0, 0 = G0->G1{p_end}
 {synopt:{opt probit}}use probit instead of logit for propensity score{p_end}
 {synopt:{opt comsup}}restrict to common propensity score support{p_end}

--- a/stata/wsga_rdd.sthlp
+++ b/stata/wsga_rdd.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.2 2026-05-26}{...}
+{* *! version 1.3.0 2026-05-26}{...}
 {viewerjumpto "Stored results" "wsga_rdd##results"}{...}
 {title:Title}
 

--- a/stata/wsga_rdd.sthlp
+++ b/stata/wsga_rdd.sthlp
@@ -45,7 +45,8 @@
 {synopt:{opt normal}}normal-approximation CIs from bootstrap SE{p_end}
 {synopt:{opt seed(#)}}RNG seed for reproducibility{p_end}
 {synopt:{opt cluster(varname)}}clustering variable for pairs-cluster bootstrap{p_end}
-{synopt:{opt wildcluster}}wild cluster bootstrap (WCB-U) with Rademacher signs; requires {opt cluster}{p_end}
+{synopt:{opt wildcluster}}unrestricted wild cluster bootstrap (WCB-U) with Rademacher signs; recommended when G < ~30; requires {opt cluster}{p_end}
+{synopt:{opt wcbrestricted}}restricted wild cluster bootstrap (WCB-R); recommended when G < ~12; requires {opt cluster}; see {it:Remarks}{p_end}
 {synopt:{opt fixedbootstrap}}fixed first-stage bootstrap for IV{p_end}
 {synopt:{opt fixedps}}hold propensity score fixed across bootstrap reps (diagnostic){p_end}
 {synopt:{opt blockbootstrap(varname)}}stratified block bootstrap{p_end}
@@ -62,6 +63,35 @@ in a sharp or fuzzy regression discontinuity (RD) design. Inverse probability
 weighting (IPW) balances observed moderators across subgroups, isolating the
 subgroup-attributable component of the effect difference.
 
+
+{marker remarks}{...}
+{title:Remarks}
+
+{pstd}
+{bf:Wild cluster bootstrap variants.}
+Two wild cluster bootstrap options are available.{p_end}
+
+{pstd}
+{opt wildcluster} runs the {it:unrestricted} WCB (WCB-U): fitted values and
+residuals from the original (unrestricted) model are sign-flipped at the
+cluster level to form a bootstrap outcome; the unrestricted model is refit on
+that outcome.  The bootstrap draws are centered at the point estimate, so
+p-values use the recentered formula
+{it:(1 + #{|draw - est| >= |est|}) / (B+1)}.
+Recommended when G < ~30.{p_end}
+
+{pstd}
+{opt wcbrestricted} runs the {it:restricted} WCB (WCB-R; MacKinnon and Webb
+2017, 2018): for each null hypothesis (H0: b_G0=0, H0: b_G1=0, H0: b_G0=b_G1),
+the restricted model imposing that null is fit, its residuals are sign-flipped,
+and the {it:unrestricted} model is refit on the resulting bootstrap outcome.
+Because the null is imposed in the residuals, the bootstrap draws are centered
+at zero under H0; p-values therefore use the non-recentered formula
+{it:(1 + #{|draw| >= |est|}) / (B+1)}.
+Confidence intervals remain empirical percentile CIs from unrestricted draws.
+WCB-R has substantially better size control than WCB-U for very small G
+(< ~12) at the cost of four model fits per bootstrap replicate instead of one.
+Neither WCB variant re-estimates the propensity score per replicate.{p_end}
 
 {title:Examples}
 
@@ -80,8 +110,11 @@ subgroup-attributable component of the effect difference.
 {pstd}Pairs-cluster bootstrap on school IDs:{p_end}
 {phang2}{cmd:. wsga rdd Y M, sgroup(G) running(X) bwidth(0.5) bsreps(200) cluster(school) seed(42)}{p_end}
 
-{pstd}Wild cluster bootstrap (recommended for small G):{p_end}
+{pstd}Unrestricted wild cluster bootstrap (recommended for G < ~30):{p_end}
 {phang2}{cmd:. wsga rdd Y M, sgroup(G) running(X) bwidth(0.5) bsreps(200) cluster(school) wildcluster seed(42)}{p_end}
+
+{pstd}Restricted wild cluster bootstrap (recommended for G < ~12):{p_end}
+{phang2}{cmd:. wsga rdd Y M, sgroup(G) running(X) bwidth(0.5) bsreps(200) cluster(school) wcbrestricted seed(42)}{p_end}
 
 
 {marker results}{...}
@@ -112,7 +145,7 @@ subgroup-attributable component of the effect difference.
 {synopt:{cmd:e(cmd)}}{cmd:wsga}{p_end}
 {synopt:{cmd:e(subcmd)}}{cmd:rdd}{p_end}
 {synopt:{cmd:e(depvar)}}name of dependent variable{p_end}
-{synopt:{cmd:e(boot_type)}}(bootstrap) {cmd:pairs} or {cmd:wild}{p_end}
+{synopt:{cmd:e(boot_type)}}(bootstrap) {cmd:pairs}, {cmd:wild}, or {cmd:wild_restricted}{p_end}
 {synopt:{cmd:e(clustvar)}}(bootstrap, clustered) clustering variable{p_end}
 {synopt:{cmd:e(blockbootstrap)}}(bootstrap, stratified) stratification variable{p_end}
 

--- a/tests/testthat/test-wild-bootstrap-restricted.R
+++ b/tests/testthat/test-wild-bootstrap-restricted.R
@@ -1,0 +1,165 @@
+# WCB-R (boot_type = "wild_restricted") tests.
+# Architecture: one combined loop per replicate --
+#   * unrestricted refit  -> CI / SE (empirical percentile, coauthor agreement)
+#   * three restricted refits (G0=0, G1=0, diff=0) -> p-values
+# P-value formula for restricted draws: (1 + #{|draw| >= |est|}) / (B+1)
+# (no recentering -- draws already centred at 0 under H0).
+
+data(rddsga_synth)
+data(wsga_did_synth)
+
+make_clustered_rdd <- function(n_clusters = 20L, seed = 1L) {
+  set.seed(seed)
+  d <- rddsga_synth
+  d$school <- sample.int(n_clusters, nrow(d), replace = TRUE)
+  d
+}
+
+make_small_did <- function(n_units = 20L, seed = 1L) {
+  set.seed(seed)
+  unit   <- rep(seq_len(n_units), each = 2L)
+  time   <- rep(c(0L, 1L), times = n_units)
+  sgroup <- rep(rbinom(n_units, 1L, 0.5), each = 2L)
+  M      <- rep(rnorm(n_units, mean = 0.4 * sgroup), each = 2L)
+  D      <- rep(rbinom(n_units, 1L, 0.5), each = 2L)
+  alpha  <- rep(rnorm(n_units), each = 2L)
+  post   <- as.integer(time == 1L)
+  tau    <- ifelse(sgroup == 1L, 3, 1)
+  y      <- alpha + 0.5 * post + tau * D * post + 0.3 * M +
+            rnorm(length(unit), sd = 0.5)
+  data.frame(unit = unit, time = time, sgroup = sgroup,
+             m = M, D = D, y = y)
+}
+
+# -- Happy path: RDD --
+
+test_that("WCB-R runs on sharp RDD and returns valid structure", {
+  d   <- make_clustered_rdd(n_clusters = 20L)
+  fit <- wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+                  noipsw = TRUE, bootstrap = TRUE, bsreps = 50, seed = 1,
+                  cluster_var = "school", boot_type = "wild_restricted")
+  expect_equal(fit$boot_type, "wild_restricted")
+  expect_equal(fit$bootstrap$N_clusters, 20L)
+  expect_true(all(unlist(fit$pval) >= 0 & unlist(fit$pval) <= 1))
+  expect_true(fit$ci$g0[["lb"]]   < fit$ci$g0[["ub"]])
+  expect_true(fit$ci$g1[["lb"]]   < fit$ci$g1[["ub"]])
+  expect_true(fit$ci$diff[["lb"]] < fit$ci$diff[["ub"]])
+})
+
+test_that("WCB-R is reproducible with seed (RDD)", {
+  d <- make_clustered_rdd(n_clusters = 20L)
+  a <- wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+                noipsw = TRUE, bootstrap = TRUE, bsreps = 30, seed = 42,
+                cluster_var = "school", boot_type = "wild_restricted")
+  b <- wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+                noipsw = TRUE, bootstrap = TRUE, bsreps = 30, seed = 42,
+                cluster_var = "school", boot_type = "wild_restricted")
+  expect_equal(a$pval, b$pval)
+  expect_equal(a$ci,   b$ci)
+})
+
+test_that("WCB-R CI equals WCB-U CI with the same seed (unrestricted draws for CI)", {
+  # The unrestricted pass (for CI/SE) uses the same sign draws as a plain
+  # WCB-U run with the same seed, so CIs must be numerically identical.
+  d     <- make_clustered_rdd(n_clusters = 20L)
+  fit_r <- wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+                    noipsw = TRUE, bootstrap = TRUE, bsreps = 100, seed = 7,
+                    cluster_var = "school", boot_type = "wild_restricted")
+  fit_u <- wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+                    noipsw = TRUE, bootstrap = TRUE, bsreps = 100, seed = 7,
+                    cluster_var = "school", boot_type = "wild")
+  expect_equal(fit_r$ci, fit_u$ci)
+})
+
+test_that("WCB-R stores boot_type_pval and boot_type_ci metadata", {
+  d   <- make_clustered_rdd(n_clusters = 20L)
+  fit <- wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+                  noipsw = TRUE, bootstrap = TRUE, bsreps = 30, seed = 1,
+                  cluster_var = "school", boot_type = "wild_restricted")
+  expect_equal(fit$bootstrap$boot_type_pval, "wild_restricted")
+  expect_equal(fit$bootstrap$boot_type_ci,   "wild")
+})
+
+# -- Happy path: DiD --
+
+test_that("WCB-R runs on DiD (cluster defaults to unit)", {
+  d   <- make_small_did(n_units = 20L)
+  fit <- wsga_did(y ~ 1 | sgroup, data = d,
+                  unit = "unit", time = "time", treat = "D",
+                  noipsw = TRUE, bootstrap = TRUE, bsreps = 50, seed = 1,
+                  boot_type = "wild_restricted")
+  expect_equal(fit$boot_type, "wild_restricted")
+  expect_equal(fit$bootstrap$N_clusters, 20L)
+  expect_true(all(unlist(fit$pval) >= 0 & unlist(fit$pval) <= 1))
+})
+
+# -- Advisory --
+
+test_that("boot_type='wild' with G<12 warns and recommends wild_restricted", {
+  d <- make_clustered_rdd(n_clusters = 10L, seed = 2L)
+  expect_warning(
+    wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+             noipsw = TRUE, bootstrap = TRUE, bsreps = 5, seed = 1,
+             cluster_var = "school", boot_type = "wild"),
+    "consider `boot_type = \"wild_restricted\"`"
+  )
+})
+
+test_that("boot_type='wild_restricted' at G<12 does NOT warn", {
+  d <- make_clustered_rdd(n_clusters = 10L, seed = 2L)
+  expect_no_warning(
+    wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+             noipsw = TRUE, bootstrap = TRUE, bsreps = 5, seed = 1,
+             cluster_var = "school", boot_type = "wild_restricted")
+  )
+})
+
+test_that("boot_type='wild' with 12<=G<30 warns to use wild but not wild_restricted", {
+  d <- make_clustered_rdd(n_clusters = 20L, seed = 2L)
+  w <- withCallingHandlers(
+    wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+             noipsw = TRUE, bootstrap = TRUE, bsreps = 5, seed = 1,
+             cluster_var = "school", boot_type = "pairs"),
+    warning = function(w) {
+      invokeRestart("muffleWarning")
+    }
+  )
+  # wild at 12<=G<30 should NOT warn about wild_restricted
+  expect_no_warning(
+    wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+             noipsw = TRUE, bootstrap = TRUE, bsreps = 5, seed = 1,
+             cluster_var = "school", boot_type = "wild")
+  )
+})
+
+# -- Validation errors --
+
+test_that("wild_restricted errors without cluster_var (RDD)", {
+  expect_error(
+    wsga_rdd(y ~ 1 | sgroup, data = rddsga_synth, running = ~ x, bwidth = 0.5,
+             noipsw = TRUE, bootstrap = TRUE, bsreps = 10,
+             boot_type = "wild_restricted"),
+    "requires a clustering variable"
+  )
+})
+
+test_that("wild_restricted errors with model = 'iv'", {
+  d <- make_clustered_rdd(n_clusters = 20L)
+  expect_error(
+    wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+             fuzzy = ~ D, model = "iv",
+             noipsw = TRUE, bootstrap = TRUE, bsreps = 10,
+             cluster_var = "school", boot_type = "wild_restricted"),
+    "not supported with `model = \"iv\"`"
+  )
+})
+
+test_that("wild_restricted errors when bootstrap = FALSE", {
+  d <- make_clustered_rdd(n_clusters = 20L)
+  expect_error(
+    wsga_rdd(y ~ 1 | sgroup, data = d, running = ~ x, bwidth = 0.5,
+             noipsw = TRUE, bootstrap = FALSE,
+             cluster_var = "school", boot_type = "wild_restricted"),
+    "requires `bootstrap = TRUE`"
+  )
+})

--- a/vignettes/wsga-did-intro.Rmd
+++ b/vignettes/wsga-did-intro.Rmd
@@ -26,7 +26,7 @@ weighting (IPW) on subgroup membership corrects for that imbalance.
 We use the bundled `wsga_did_synth` dataset: a balanced two-period panel of
 500 units (1,000 rows). The binary subgroup `sgroup`, the moderator `m`, and
 the treatment indicator `D` are all constant within unit. `D` is independent of
-`sgroup`, but `m` has a higher mean in `sgroup = 1` — exactly the imbalance
+`sgroup`, but `m` has a higher mean in `sgroup = 1` -- exactly the imbalance
 that IPW is designed to address. True per-subgroup effects are
 `tau_0 = 1`, `tau_1 = 3` (true difference = 2).
 
@@ -41,7 +41,7 @@ table(wsga_did_synth$sgroup, wsga_did_synth$time)
 
 The unweighted estimator fits a long-form TWFE regression (unit and time
 fixed effects) interacted with subgroup. With `noipsw = TRUE`, no IPW
-correction is applied — coefficients reflect both the subgroup effect and
+correction is applied -- coefficients reflect both the subgroup effect and
 the contribution of imbalanced moderators.
 
 ```{r noipsw}
@@ -86,7 +86,7 @@ treatment effect is identified off the treated cells.
 ### Step 3: Cluster bootstrap inference
 
 `wsga_did()` defaults `cluster_var` to `unit`, so the bootstrap is a
-pairs-cluster bootstrap over panel units (Cameron–Gelbach–Miller).
+pairs-cluster bootstrap over panel units (Cameron-Gelbach-Miller).
 
 ```{r bootstrap, cache = TRUE}
 fit_boot <- wsga_did(
@@ -114,4 +114,5 @@ clusters were resampled.
 | `treat`       | Column name of the binary treatment indicator (constant within unit). |
 | `post_value`  | Value of `time` denoting the post period. Defaults to `max(time)`. |
 | `cluster_var` | Column defining clusters for the bootstrap and analytical SE. Defaults to `unit` for DiD. |
+| `boot_type`   | `"pairs"` (default), `"wild"` (WCB-U, recommended for G < ~30), or `"wild_restricted"` (WCB-R, recommended for G < ~12). WCB-R uses restricted residuals to form the bootstrap outcome; p-values use a non-recentered formula; CIs remain empirical percentile from unrestricted draws. See MacKinnon and Webb (2017, 2018). |
 | `inference`   | `"empirical"` (default with bootstrap), `"normal"`, or `"analytical"` (cluster-robust sandwich when `cluster_var` is set). |

--- a/vignettes/wsga-intro.Rmd
+++ b/vignettes/wsga-intro.Rmd
@@ -130,7 +130,8 @@ head(fit_boot$bootstrap$draws)
 | `m` | IPW mode: `2` = balance both groups (default), `1` = ATT G=1, `0` = ATT G=0 |
 | `comsup` | Restrict to common propensity score support |
 | `rbalance` | Balance table means: `0` = at cutoff (default), `1` = in sample |
-| `boot_type` | `"pairs"` (default), `"wild"` (WCB-U, recommended for G < ~30), or `"wild_restricted"` (WCB-R, recommended for G < ~12). WCB-R uses restricted residuals to form the bootstrap outcome, yielding better size control at very small cluster counts. P-values use a non-recentered formula; CIs remain empirical percentile from unrestricted draws. See MacKinnon and Webb (2017, 2018). |
+| `cluster_var` | Column name defining clusters for the bootstrap. When set, the pairs bootstrap resamples whole clusters (Cameron-Gelbach-Miller); required for `boot_type = "wild"` or `"wild_restricted"`. Default `NULL` (row-level bootstrap). |
+| `boot_type` | `"pairs"` (default), `"wild"` (WCB-U, recommended for G < ~30), or `"wild_restricted"` (WCB-R, recommended for G < ~12). WCB-R uses restricted residuals to form the bootstrap outcome, yielding better size control at very small cluster counts. P-values use a non-recentered formula; CIs remain empirical percentile from unrestricted draws. See MacKinnon and Webb (2017, 2018). Requires `cluster_var`. |
 | `inference` | `"empirical"` (default with bootstrap), `"normal"` (bootstrap SE + normal-approx CI), or `"analytical"` (default without bootstrap, sandwich/cluster-robust SE) |
 | `block_var` | Column name for stratified block bootstrap. Ignored with `boot_type = "wild"` or `"wild_restricted"`. |
 | `vce` | Sandwich SE type: `"HC1"` (default), `"HC0"`, `"HC2"`, `"HC3"`, `"cluster"` |

--- a/vignettes/wsga-intro.Rmd
+++ b/vignettes/wsga-intro.Rmd
@@ -43,7 +43,7 @@ fit_unw <- wsga_rdd(
   data      = rddsga_synth,
   running   = ~ x,
   bwidth    = 0.5,
-  noipsw    = TRUE,         # no IPW — just separate local linear regressions
+  noipsw    = TRUE,         # no IPW -- just separate local linear regressions
   bootstrap = FALSE
 )
 print(fit_unw)
@@ -117,7 +117,7 @@ confint(fit_boot)
 # Number of observations within bandwidth
 nobs(fit_boot)
 
-# Bootstrap draws (B × 2 matrix)
+# Bootstrap draws (B x 2 matrix)
 head(fit_boot$bootstrap$draws)
 ```
 
@@ -130,7 +130,8 @@ head(fit_boot$bootstrap$draws)
 | `m` | IPW mode: `2` = balance both groups (default), `1` = ATT G=1, `0` = ATT G=0 |
 | `comsup` | Restrict to common propensity score support |
 | `rbalance` | Balance table means: `0` = at cutoff (default), `1` = in sample |
+| `boot_type` | `"pairs"` (default), `"wild"` (WCB-U, recommended for G < ~30), or `"wild_restricted"` (WCB-R, recommended for G < ~12). WCB-R uses restricted residuals to form the bootstrap outcome, yielding better size control at very small cluster counts. P-values use a non-recentered formula; CIs remain empirical percentile from unrestricted draws. See MacKinnon and Webb (2017, 2018). |
 | `inference` | `"empirical"` (default with bootstrap), `"normal"` (bootstrap SE + normal-approx CI), or `"analytical"` (default without bootstrap, sandwich/cluster-robust SE) |
-| `block_var` | Column name for stratified block bootstrap |
+| `block_var` | Column name for stratified block bootstrap. Ignored with `boot_type = "wild"` or `"wild_restricted"`. |
 | `vce` | Sandwich SE type: `"HC1"` (default), `"HC0"`, `"HC2"`, `"HC3"`, `"cluster"` |
 | `ps_model` | `"logit"` (default) or `"probit"` for propensity score |


### PR DESCRIPTION
## Summary

- Adds `boot_type = "wild_restricted"` in R (`wsga_rdd`, `wsga_did`) and `wcbrestricted` option in Stata (`wsga rdd`, `wsga did`)
- WCB-R architecture: one combined loop per replicate -- unrestricted refit for empirical percentile CIs/SE (coauthor agreement), three restricted refits (H0: G0=0, H0: G1=0, H0: G0=G1) for p-values
- P-value formula for restricted draws: `(1 + #{|draw| >= |est|}) / (B+1)` -- no recentering, because restricted residuals are already centred at 0 under H0 (MacKinnon & Webb 2017, eq. 8)
- G<12 advisory added: `boot_type = "wild"` at small-G now recommends switching to `"wild_restricted"`
- `e(boot_type) = "wild_restricted"` in Stata; `fit$bootstrap$boot_type_pval = "wild_restricted"` and `boot_type_ci = "wild"` in R for provenance tracking
- Note: Stata option is `wcbrestricted` (not `wildcluster_r`) because Stata's `syntax` command does not allow underscores in option names
- Closes #36; constraint from issue #20 (test-inversion CIs deferred per coauthor agreement -- see comment on #20) preserved

## Test plan

- [x] R: 20 new tests in `tests/testthat/test-wild-bootstrap-restricted.R` (happy path RDD + DiD, CI=WCB-U with same seed, metadata, advisory thresholds, validation errors) -- all pass; full suite 166/166 green
- [x] Stata RDD: 5 new smoke tests in `stata/tests/smoke_rdd_wild.do` (tests 11-15) -- all pass
- [x] Stata DiD: 4 new smoke tests in `stata/tests/smoke_did_wild.do` (WCB-R tests) -- all pass
- [x] CI: R CMD check on macOS / Windows / Ubuntu x release/devel