### PR TITLE
docs: correct stale inst/ path references in 1.3.1 NEWS (v1.3.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 1.3.1
+Version: 1.3.2
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,29 @@
 # wsga (R package) NEWS
 
+## wsga 1.3.2 (2026-05-27)
+
+### Documentation
+
+- Correct stale `inst/` path references in the 1.3.1 NEWS entry. The
+  Monte Carlo simulation files were moved from `inst/` to a top-level
+  `simulation/` directory in a follow-up commit on the same PR (`inst/`
+  semantics are for files that ship with the installed package, which
+  these never were since they were `.Rbuildignore`-d). NEWS now points
+  at the correct paths.
+
+---
+
 ## wsga 1.3.1 (2026-05-26)
 
 ### Internal
 
-- Add Monte Carlo simulation study (`inst/run_simulations.R`) validating
-  four core estimator properties: bias removal (S1), size control under
-  the null (S2), power as a function of K moderators (S3), and sensitivity
-  to unobservable confounding (S4). Full results (1000 reps, 10 cores)
-  saved to `inst/simulation_results/*.csv`. Closes #29.
+- Add Monte Carlo simulation study (`simulation/run_simulations.R`)
+  validating four core estimator properties: bias removal (S1), size
+  control under the null (S2), power as a function of K moderators (S3),
+  and sensitivity to unobservable confounding (S4). Full results
+  (1000 reps, 10 cores) saved to `simulation/simulation_results/*.csv`.
+  A self-contained Quarto report rendering all four scenarios with plots
+  is at `simulation/simulation_report.html`. Closes #29.
 
 ---
 

--- a/stata/rddsga.ado
+++ b/stata/rddsga.ado
@@ -1,4 +1,4 @@
-*! 1.3.1 Alvaro Carril 2026-05-26
+*! 1.3.2 Alvaro Carril 2026-05-27
 program define rddsga
   version 11.1
   di as error "rddsga is removed. Use {cmd:wsga rdd} instead."

--- a/stata/rddsga.pkg
+++ b/stata/rddsga.pkg
@@ -1,4 +1,4 @@
-v 1.3.1
+v 1.3.2
 d 'RDDSGA': Deprecated alias for the wsga package
 d
 d  rddsga is the previous name of the wsga (Weighted Subgroup Analysis)
@@ -18,7 +18,7 @@ d KW: IPW
 d
 d Requires: Stata version 11
 d
-d Distribution-Date: 20260526
+d Distribution-Date: 20260527
 d
 d Authors: Alvaro Carril, Mercado Libre
 d          Andre Cazor, PUC Chile

--- a/stata/rddsga.sthlp
+++ b/stata/rddsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.1 2026-05-26}{...}
+{* *! version 1.3.2 2026-05-27}{...}
 {title:Title}
 
 {pstd}

--- a/stata/stata.toc
+++ b/stata/stata.toc
@@ -1,4 +1,4 @@
-v 1.3.1
+v 1.3.2
 d Alvaro Carril
 p wsga Weighted subgroup analysis (RD designs; sharp DiD planned)
 p rddsga (deprecated alias of wsga; installs the same files)

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,4 +1,4 @@
-*! 1.3.1 Alvaro Carril 2026-05-26
+*! 1.3.2 Alvaro Carril 2026-05-27
 
 // -- Dispatcher ----------------------------------------------------------------
 program define wsga

--- a/stata/wsga.pkg
+++ b/stata/wsga.pkg
@@ -1,4 +1,4 @@
-v 1.3.1
+v 1.3.2
 d 'WSGA': Weighted subgroup analysis
 d
 d  wsga conducts weighted subgroup analysis for research designs that
@@ -23,7 +23,7 @@ d KW: Inverse probability weighting
 d
 d Requires: Stata version 11
 d
-d Distribution-Date: 20260526
+d Distribution-Date: 20260527
 d
 d Authors: Alvaro Carril, Mercado Libre
 d          Andre Cazor, PUC Chile

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.1 2026-05-26}{...}
+{* *! version 1.3.2 2026-05-27}{...}
 {title:Title}
 
 {pstd}

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.1 2026-05-26}{...}
+{* *! version 1.3.2 2026-05-27}{...}
 {viewerjumpto "Stored results" "wsga_did##results"}{...}
 {title:Title}
 

--- a/stata/wsga_rdd.sthlp
+++ b/stata/wsga_rdd.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.1 2026-05-26}{...}
+{* *! version 1.3.2 2026-05-27}{...}
 {viewerjumpto "Stored results" "wsga_rdd##results"}{...}
 {title:Title}
 


### PR DESCRIPTION
## Summary

- Update the 1.3.1 NEWS bullet to reference `simulation/run_simulations.R` and `simulation/simulation_results/*.csv` (the paths in main since PR #41 moved the files out of `inst/`)
- Add a new 1.3.2 NEWS entry recording the correction
- Bump version 1.3.1 -> 1.3.2 across all 11 files

## Test plan

- [x] All 11 version-bearing files updated
- [x] 1.3.1 NEWS entry now points at correct paths
- [x] 1.3.1 release date preserved (2026-05-26)