### PR TITLE
fix(Stata/rdd): IPW bootstrap r(111) — refit saved cmdline, not clobbered e(cmdline) (#43)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.gph
 *.log
 
+# Replication microdata (not for public repo)
+data/fujiwara/
+
 # R
 .Rproj.user
 .Rhistory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 1.3.2
+Version: 1.3.3
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # wsga (R package) NEWS
 
+## wsga 1.3.3 (2026-05-28)
+
+### Bug fixes
+
+- fix(Stata/rdd): the IPW (`m()`-weighted) RDD bootstrap aborted with
+  `r(111)` on the first replicate. The per-replicate propensity-score
+  `logit` clobbered `e(cmdline)`, so the pairs-bootstrap loop re-ran the
+  logit instead of the outcome regression and the treatment-coefficient
+  lookup failed. The loop now refits the outcome command saved before the
+  loop. Affected all `m()`-weighted RDD bootstraps (reduced form, first
+  stage, and 2SLS); `noipsw` was never affected. Added an IPW-bootstrap
+  smoke test (`stata/tests/smoke_rdd_ipw_boot.do`). (#43)
+
+---
+
 ## wsga 1.3.2 (2026-05-27)
 
 ### Documentation

--- a/stata/rddsga.ado
+++ b/stata/rddsga.ado
@@ -1,4 +1,4 @@
-*! 1.3.2 Alvaro Carril 2026-05-27
+*! 1.3.3 Alvaro Carril 2026-05-28
 program define rddsga
   version 11.1
   di as error "rddsga is removed. Use {cmd:wsga rdd} instead."

--- a/stata/rddsga.pkg
+++ b/stata/rddsga.pkg
@@ -1,4 +1,4 @@
-v 1.3.2
+v 1.3.3
 d 'RDDSGA': Deprecated alias for the wsga package
 d
 d  rddsga is the previous name of the wsga (Weighted Subgroup Analysis)
@@ -18,7 +18,7 @@ d KW: IPW
 d
 d Requires: Stata version 11
 d
-d Distribution-Date: 20260527
+d Distribution-Date: 20260528
 d
 d Authors: Alvaro Carril, Mercado Libre
 d          Andre Cazor, PUC Chile

--- a/stata/rddsga.sthlp
+++ b/stata/rddsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.2 2026-05-27}{...}
+{* *! version 1.3.3 2026-05-28}{...}
 {title:Title}
 
 {pstd}

--- a/stata/stata.toc
+++ b/stata/stata.toc
@@ -1,4 +1,4 @@
-v 1.3.2
+v 1.3.3
 d Alvaro Carril
 p wsga Weighted subgroup analysis (RD designs; sharp DiD planned)
 p rddsga (deprecated alias of wsga; installs the same files)

--- a/stata/tests/smoke_rdd_ipw_boot.do
+++ b/stata/tests/smoke_rdd_ipw_boot.do
@@ -1,0 +1,64 @@
+// smoke_rdd_ipw_boot.do -- IPW reduced-form bootstrap regression test (issue #43)
+//
+// Before the fix, the per-replicate propensity-score logit clobbered e(cmdline),
+// so the pairs-bootstrap loop re-ran the logit instead of the outcome model and
+// aborted with r(111) "[0.G#1._cutoff] not found" on the FIRST IPW replicate.
+// Every IPW (m()) RDD bootstrap was affected; noipsw was not. This test runs an
+// IPW bootstrap (which used to crash) and a noipsw bootstrap (regression guard).
+//
+// Run from rddsga-repo/:
+//   stata-mp -b do stata/tests/smoke_rdd_ipw_boot.do && cat smoke_rdd_ipw_boot.log
+
+quietly do stata/wsga.ado
+
+local n_fail = 0
+
+// --- Test 1: IPW reduced-form bootstrap must run (was aborting with r(111)) ---
+use stata/rddsga_synth, clear
+capture wsga rdd Y, sgroup(G) running(X) bwidth(20) reducedform ///
+    balance(W1 W2) m(2) bsreps(40) seed(42) rbalance(0)
+if _rc != 0 {
+    di as error "FAIL [IPW bootstrap]: rc=" _rc " (expected 0)"
+    local ++n_fail
+}
+else if mi(e(b)[1,1]) | mi(e(b)[1,2]) {
+    di as error "FAIL [IPW estimates]: G0=" e(b)[1,1] " G1=" e(b)[1,2]
+    local ++n_fail
+}
+else {
+    di as result "PASS [IPW bootstrap]: G0=" e(b)[1,1] " G1=" e(b)[1,2]
+}
+
+// --- Test 2: noipsw pairs bootstrap still works (regression guard) ---
+use stata/rddsga_synth, clear
+capture wsga rdd Y, sgroup(G) running(X) bwidth(20) reducedform noipsw ///
+    bsreps(40) seed(42) rbalance(0)
+if _rc == 0 & !mi(e(b)[1,1]) {
+    di as result "PASS [noipsw bootstrap]"
+}
+else {
+    di as error "FAIL [noipsw bootstrap]: rc=" _rc
+    local ++n_fail
+}
+
+// --- Test 3: IPW fuzzy IV + first-stage bootstrap (same shared loop) ---
+foreach spec in "ivregress" "firststage" {
+    use stata/rddsga_synth, clear
+    capture wsga rdd Y, sgroup(G) running(X) bwidth(20) `spec' fuzzy(D) ///
+        balance(W1 W2) m(2) bsreps(30) seed(42) rbalance(0)
+    if _rc == 0 & !mi(e(b)[1,1]) {
+        di as result "PASS [IPW `spec' bootstrap]"
+    }
+    else {
+        di as error "FAIL [IPW `spec' bootstrap]: rc=" _rc
+        local ++n_fail
+    }
+}
+
+if `n_fail' == 0 {
+    di as result _newline "All IPW-bootstrap smoke tests passed."
+}
+else {
+    di as error _newline "`n_fail' IPW-bootstrap smoke test(s) FAILED."
+    exit 1
+}

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -996,7 +996,11 @@ program define _wsga_rdd_myboo, eclass
       qui replace `kernelipsw' = `ipsweight' * `kwt'
     }
 
-      qui `e(cmdline)'
+      // Refit the SAVED outcome command, not e(cmdline): the propensity-score
+      // logit above clobbers e(cmdline), so `e(cmdline)' would re-run the logit
+      // (which has no treatment coefficient) and _b[] would fail with r(111) on
+      // every IPW replicate (#43).
+      qui `_saved_cmdline'
     }
     tempname this_run
     // Non-IV or bootstrap-both-stages

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,4 +1,4 @@
-*! 1.3.2 Alvaro Carril 2026-05-27
+*! 1.3.3 Alvaro Carril 2026-05-28
 
 // -- Dispatcher ----------------------------------------------------------------
 program define wsga

--- a/stata/wsga.pkg
+++ b/stata/wsga.pkg
@@ -1,4 +1,4 @@
-v 1.3.2
+v 1.3.3
 d 'WSGA': Weighted subgroup analysis
 d
 d  wsga conducts weighted subgroup analysis for research designs that
@@ -23,7 +23,7 @@ d KW: Inverse probability weighting
 d
 d Requires: Stata version 11
 d
-d Distribution-Date: 20260527
+d Distribution-Date: 20260528
 d
 d Authors: Alvaro Carril, Mercado Libre
 d          Andre Cazor, PUC Chile

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.2 2026-05-27}{...}
+{* *! version 1.3.3 2026-05-28}{...}
 {title:Title}
 
 {pstd}

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.2 2026-05-27}{...}
+{* *! version 1.3.3 2026-05-28}{...}
 {viewerjumpto "Stored results" "wsga_did##results"}{...}
 {title:Title}
 

--- a/stata/wsga_rdd.sthlp
+++ b/stata/wsga_rdd.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.2 2026-05-27}{...}
+{* *! version 1.3.3 2026-05-28}{...}
 {viewerjumpto "Stored results" "wsga_rdd##results"}{...}
 {title:Title}
 


### PR DESCRIPTION
## Summary

Fixes #43. The IPW (`m()`-weighted) RDD bootstrap aborted with `r(111)` ("[0.svar#1._cutoff] not found") on the first replicate.

**Root cause:** inside `_wsga_rdd_myboo`'s pairs+psw loop, the per-replicate propensity-score `logit` clobbers `e(cmdline)`. The loop then ran `qui \`e(cmdline)'`, re-executing the *logit* instead of the outcome regression. The logit's coefficient vector has no `i.svar#1._cutoff` term, so the extraction `_b[0.svar#1._cutoff]` failed.

This was deterministic and affected **every** `m()`-weighted RDD bootstrap (reduced form, first stage, and 2SLS — all share `_wsga_rdd_myboo`), independent of bandwidth, block, or sample. `noipsw` bootstraps were never affected (no logit to clobber `e(cmdline)`), which is why it went unnoticed — there was no IPW-bootstrap test.

`wsga did` is **not** affected: its loop refits an explicit `xtreg` and never reads `e(cmdline)`.

## Change

- `stata/wsga.ado`: refit `_saved_cmdline` (captured before the loop) instead of the clobbered `e(cmdline)`. One line + comment.
- `stata/tests/smoke_rdd_ipw_boot.do`: new regression test exercising IPW reduced-form, `noipsw`, and IPW fuzzy `ivregress`/`firststage` bootstraps.
- `.gitignore`: ignore `data/fujiwara/` (local replication microdata).

## Verification

- New smoke test: 4/4 pass (e.g. IPW reduced-form G0=−0.288, G1=0.985).
- Full Stata smoke suite (rdd, rdd_wild, did, did_wild, inference_modes): all pass.
- R `testthat`: 166 pass, 0 fail (R is unaffected by this bug).
- Confirmed on the Fujiwara replication: the originally-failing command now completes (was r(111) at rep 1).

## Scope note

This PR is intentionally minimal — just the crash fix. Follow-up bootstrap **hardening** (graceful drop of degenerate replicates + `B_ok` reporting + cell-count guard against silent `_b=0` contamination + drop-rate warnings, and a fail-fast for structurally unidentified subgroups in both Stata and R) is tracked separately and will build on this.
