### PR TITLE
fix(Stata/rdd): harden RDD bootstrap + cross-language fail-fast (#45)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wsga
 Title: Weighted Subgroup Analysis
-Version: 1.3.3
+Version: 1.3.4
 Authors@R:
     person("Alvaro", "Carril", email = "alvarocarril@gmail.com", role = c("aut", "cre"))
 Description: Implements inverse probability weighted (IPW) subgroup analysis for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # wsga (R package) NEWS
 
+## wsga 1.3.4 (2026-05-28)
+
+### Bug fixes
+
+- fix(Stata/rdd): harden the RDD bootstrap (follow-up to 1.3.3 / #43).
+  Degenerate replicates are now dropped instead of aborting the run; a
+  cell-count guard drops resamples that empty a subgroup x cutoff cell
+  (which would otherwise enter the bootstrap distribution as a spurious
+  `0`); `e(B_ok)` now reports the true surviving-replicate count and is
+  used in the p-value / percentile-CI denominators; warnings fire on
+  dropped replicates (prominent above a 10% drop rate), with a clean
+  abort if all replicates fail.
+- fix: clear fail-fast error (R and Stata) when a subgroup has no
+  observations on one side of the cutoff within the estimation sample
+  (its RD effect is not identified). Previously crashed cryptically
+  (`subscript out of bounds` in R; mid-bootstrap `r(111)` in Stata). (#45)
+
+---
+
 ## wsga 1.3.3 (2026-05-28)
 
 ### Bug fixes

--- a/R/wsga.R
+++ b/R/wsga.R
@@ -564,6 +564,22 @@ wsga_did <- function(formula,
   # Active observations for estimation (non-zero weight and within bw)
   active <- touse & within_bw & final_wt > 0
 
+  # Fail-fast (RDD): each subgroup needs observations on BOTH sides of the cutoff
+  # within the active sample, otherwise its RD jump is not identified. Stop with a
+  # clear message rather than failing cryptically downstream (#43).
+  if (design == "rdd") {
+    for (g in c(0L, 1L)) {
+      n_below <- sum(active & G == g & Z == 0)
+      n_above <- sum(active & G == g & Z == 1)
+      if (n_below == 0 || n_above == 0)
+        stop(sprintf(
+          paste0("Subgroup %s==%d has no observations on one side of the cutoff ",
+                 "within the active sample (below=%d, above=%d); its RD effect is ",
+                 "not identified. Check the bandwidth and subgroup variable."),
+          sgroup_name, g, n_below, n_above), call. = FALSE)
+    }
+  }
+
   # Unweighted counts (for balance table)
   N_G0_unw <- sum(touse & within_bw & G == 0)
   N_G1_unw <- sum(touse & within_bw & G == 1)

--- a/stata/rddsga.ado
+++ b/stata/rddsga.ado
@@ -1,4 +1,4 @@
-*! 1.3.3 Alvaro Carril 2026-05-28
+*! 1.3.4 Alvaro Carril 2026-05-28
 program define rddsga
   version 11.1
   di as error "rddsga is removed. Use {cmd:wsga rdd} instead."

--- a/stata/rddsga.pkg
+++ b/stata/rddsga.pkg
@@ -1,4 +1,4 @@
-v 1.3.3
+v 1.3.4
 d 'RDDSGA': Deprecated alias for the wsga package
 d
 d  rddsga is the previous name of the wsga (Weighted Subgroup Analysis)

--- a/stata/rddsga.sthlp
+++ b/stata/rddsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.3 2026-05-28}{...}
+{* *! version 1.3.4 2026-05-28}{...}
 {title:Title}
 
 {pstd}

--- a/stata/stata.toc
+++ b/stata/stata.toc
@@ -1,4 +1,4 @@
-v 1.3.3
+v 1.3.4
 d Alvaro Carril
 p wsga Weighted subgroup analysis (RD designs; sharp DiD planned)
 p rddsga (deprecated alias of wsga; installs the same files)

--- a/stata/tests/smoke_rdd_ipw_boot.do
+++ b/stata/tests/smoke_rdd_ipw_boot.do
@@ -1,10 +1,11 @@
-// smoke_rdd_ipw_boot.do -- IPW reduced-form bootstrap regression test (issue #43)
+// smoke_rdd_ipw_boot.do -- IPW bootstrap + degenerate-replicate handling (issue #43)
 //
-// Before the fix, the per-replicate propensity-score logit clobbered e(cmdline),
-// so the pairs-bootstrap loop re-ran the logit instead of the outcome model and
-// aborted with r(111) "[0.G#1._cutoff] not found" on the FIRST IPW replicate.
-// Every IPW (m()) RDD bootstrap was affected; noipsw was not. This test runs an
-// IPW bootstrap (which used to crash) and a noipsw bootstrap (regression guard).
+// Regression test for the bug where the propensity-score logit clobbered
+// e(cmdline), so the pairs-bootstrap loop re-ran the logit instead of the
+// outcome model and aborted with r(111) "[0.G#1._cutoff] not found" on the
+// FIRST IPW replicate. Also covers the graceful handling of genuinely
+// degenerate replicates (thin subgroup x cutoff cells) and the fail-fast
+// guard for structurally unidentified subgroups.
 //
 // Run from rddsga-repo/:
 //   stata-mp -b do stata/tests/smoke_rdd_ipw_boot.do && cat smoke_rdd_ipw_boot.log
@@ -13,44 +14,90 @@ quietly do stata/wsga.ado
 
 local n_fail = 0
 
-// --- Test 1: IPW reduced-form bootstrap must run (was aborting with r(111)) ---
+// --- Test 1: healthy IPW bootstrap must run (was aborting with r(111)) ---
 use stata/rddsga_synth, clear
 capture wsga rdd Y, sgroup(G) running(X) bwidth(20) reducedform ///
     balance(W1 W2) m(2) bsreps(40) seed(42) rbalance(0)
 if _rc != 0 {
-    di as error "FAIL [IPW bootstrap]: rc=" _rc " (expected 0)"
+    di as error "FAIL [healthy IPW bootstrap]: rc=" _rc " (expected 0)"
+    local ++n_fail
+}
+else if e(B_ok) != e(N_reps) {
+    di as error "FAIL [healthy IPW B_ok]: B_ok=" e(B_ok) " != N_reps=" e(N_reps)
     local ++n_fail
 }
 else if mi(e(b)[1,1]) | mi(e(b)[1,2]) {
-    di as error "FAIL [IPW estimates]: G0=" e(b)[1,1] " G1=" e(b)[1,2]
+    di as error "FAIL [healthy IPW estimates]: G0=" e(b)[1,1] " G1=" e(b)[1,2]
     local ++n_fail
 }
 else {
-    di as result "PASS [IPW bootstrap]: G0=" e(b)[1,1] " G1=" e(b)[1,2]
+    di as result "PASS [healthy IPW bootstrap]: B_ok=" e(B_ok) "/" e(N_reps)
 }
 
 // --- Test 2: noipsw pairs bootstrap still works (regression guard) ---
 use stata/rddsga_synth, clear
 capture wsga rdd Y, sgroup(G) running(X) bwidth(20) reducedform noipsw ///
     bsreps(40) seed(42) rbalance(0)
-if _rc == 0 & !mi(e(b)[1,1]) {
-    di as result "PASS [noipsw bootstrap]"
+if _rc == 0 & e(B_ok) == e(N_reps) {
+    di as result "PASS [noipsw bootstrap]: B_ok=" e(B_ok) "/" e(N_reps)
 }
 else {
-    di as error "FAIL [noipsw bootstrap]: rc=" _rc
+    di as error "FAIL [noipsw bootstrap]: rc=" _rc " B_ok=" e(B_ok) " N_reps=" e(N_reps)
     local ++n_fail
 }
 
-// --- Test 3: IPW fuzzy IV + first-stage bootstrap (same shared loop) ---
+// --- Test 3: degenerate replicates (thin cell) are dropped, not silently kept ---
+// G0 has only 2 below-cutoff obs, so some resamples empty that cell.
+use stata/rddsga_synth, clear
+set seed 55
+keep if abs(X) < 12
+gen byte _above = X > 0
+gen byte sg = 1
+replace sg = 0 if _above==1 & runiform() < 0.5
+gen double _r = runiform() if _above==0
+sort _r
+gen long _rk = _n if _above==0
+replace sg = 0 if _above==0 & _rk <= 2
+replace sg = 1 if _above==0 & _rk >  2
+capture wsga rdd Y, sgroup(sg) running(X) bwidth(12) reducedform ///
+    balance(W1 W2) m(2) bsreps(100) seed(42) rbalance(0)
+if _rc != 0 {
+    di as error "FAIL [thin-cell run]: rc=" _rc " (expected 0)"
+    local ++n_fail
+}
+else if e(B_ok) >= 1 & e(B_ok) < e(N_reps) {
+    di as result "PASS [thin-cell partial drop]: B_ok=" e(B_ok) "/" e(N_reps) " (some reps dropped)"
+}
+else {
+    di as error "FAIL [thin-cell partial drop]: B_ok=" e(B_ok) " N_reps=" e(N_reps) " (expected 1 <= B_ok < N_reps)"
+    local ++n_fail
+}
+drop _above _r _rk
+
+// --- Test 4: fail-fast on a structurally unidentified subgroup ---
+// One subgroup lives entirely on one side of the cutoff -> abort with r(111).
+use stata/rddsga_synth, clear
+gen byte sg1 = (X < 0)        // sg1==1 iff below cutoff: no below-cutoff obs for sg1==0
+capture wsga rdd Y, sgroup(sg1) running(X) bwidth(20) reducedform ///
+    noipsw bsreps(10) seed(1)
+if _rc == 111 {
+    di as result "PASS [fail-fast]: unidentified subgroup correctly aborted with r(111)"
+}
+else {
+    di as error "FAIL [fail-fast]: expected r(111), got rc=" _rc
+    local ++n_fail
+}
+
+// --- Test 5: IPW fuzzy ivregress + first-stage bootstrap (same shared loop) ---
 foreach spec in "ivregress" "firststage" {
     use stata/rddsga_synth, clear
     capture wsga rdd Y, sgroup(G) running(X) bwidth(20) `spec' fuzzy(D) ///
         balance(W1 W2) m(2) bsreps(30) seed(42) rbalance(0)
-    if _rc == 0 & !mi(e(b)[1,1]) {
-        di as result "PASS [IPW `spec' bootstrap]"
+    if _rc == 0 & e(B_ok) == e(N_reps) & !mi(e(b)[1,1]) {
+        di as result "PASS [IPW `spec' bootstrap]: B_ok=" e(B_ok) "/" e(N_reps)
     }
     else {
-        di as error "FAIL [IPW `spec' bootstrap]: rc=" _rc
+        di as error "FAIL [IPW `spec' bootstrap]: rc=" _rc " B_ok=" e(B_ok)
         local ++n_fail
     }
 }

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -1,4 +1,4 @@
-*! 1.3.3 Alvaro Carril 2026-05-28
+*! 1.3.4 Alvaro Carril 2026-05-28
 
 // -- Dispatcher ----------------------------------------------------------------
 program define wsga

--- a/stata/wsga.ado
+++ b/stata/wsga.ado
@@ -803,6 +803,23 @@ program define _wsga_rdd_myboo, eclass
   // Store results: functions
   tempvar esample
   gen `esample' = e(sample)
+  // Fail-fast: each subgroup must have observations on BOTH sides of the cutoff
+  // within the estimation sample, otherwise its RD jump is not identified. Abort
+  // now with a clear message rather than crashing mid-bootstrap (#43). The check
+  // is on cutoff side (_cutoff), which is the RD identification precondition for
+  // both sharp and fuzzy designs (cvar is the take-up var in the fuzzy path).
+  forvalues g = 0/1 {
+    qui count if `esample' & `svar' == `g' & _cutoff == 0
+    local _n_below = r(N)
+    qui count if `esample' & `svar' == `g' & _cutoff == 1
+    local _n_above = r(N)
+    if `_n_below' == 0 | `_n_above' == 0 {
+      di as error "wsga rdd: subgroup `svar'==`g' has no observations on one side of the"
+      di as error "cutoff within the estimation sample (below=`_n_below', above=`_n_above')."
+      di as error "Its RD effect is not identified. Check the bandwidth and subgroup variable."
+      exit 111
+    }
+  }
   // Extract b submatrix with subgroup coefficients
   matrix b = e(b)
   matrix b = b[1, "0.`svar'#1.`cvar'".."1.`svar'#1.`cvar'"]
@@ -876,8 +893,10 @@ program define _wsga_rdd_myboo, eclass
   _dots 0, title(`_boot_title') reps(`B')
   cap mat drop cumulative
   if "`seed'" != "" set seed `seed'
+  local B_ok = 0
   tempvar COMSUP_b
   forvalues i=1/`B' {
+    local _rep_ok = 1
     preserve
     if "`wildcluster'" != "" | "`wcbrestricted'" != "" {
       // Draw one Rademacher sign per cluster, broadcast to rows.
@@ -888,20 +907,25 @@ program define _wsga_rdd_myboo, eclass
 
       // Unrestricted y_star -> CI / SE draw (same for WCB-U and WCB-R)
       qui gen double `_wsga_ystar' = `_wsga_xb' + `_wsga_sign' * `_wsga_resid' if `esample'
-      qui `_wsga_cmd_name' `_wsga_ystar' `_wsga_cmd_rhs'
+      capture qui `_wsga_cmd_name' `_wsga_ystar' `_wsga_cmd_rhs'
+      if _rc local _rep_ok = 0
       // Coefficient extraction happens below (shared with pairs path)
 
-      if "`wcbrestricted'" != "" {
+      if "`wcbrestricted'" != "" & `_rep_ok' {
         // Three restricted refits on unrestricted model; p-value counters updated.
         // P-value formula: (1 + #{|draw| >= |est|}) / (B+1) -- no recentering,
         // because restricted draws are centred at 0 under H0 by construction
         // (MacKinnon & Webb 2017, eq. 8).
+        // Refit and _b[] access are in one capture block so an omitted coefficient
+        // in either step skips the counter increment gracefully (#43).
         tempvar _wsga_ys_r0 _wsga_ys_r1 _wsga_ys_rdiff
         qui gen double `_wsga_ys_r0' = ///
           `_wsga_xb_r0' + `_wsga_sign' * `_wsga_resid_r0' if `esample'
-        capture qui `_wsga_cmd_name' `_wsga_ys_r0' `_wsga_cmd_rhs'
-        if !_rc {
+        capture {
+          qui `_wsga_cmd_name' `_wsga_ys_r0' `_wsga_cmd_rhs'
           scalar _wcbr_draw_g0 = _b[0.`svar'#1.`cvar']
+        }
+        if !_rc {
           if abs(_wcbr_draw_g0) >= abs(b[1,1]) ///
             scalar _wcbr_count_g0 = _wcbr_count_g0 + 1
           scalar _wcbr_B_g0 = _wcbr_B_g0 + 1
@@ -909,9 +933,11 @@ program define _wsga_rdd_myboo, eclass
 
         qui gen double `_wsga_ys_r1' = ///
           `_wsga_xb_r1' + `_wsga_sign' * `_wsga_resid_r1' if `esample'
-        capture qui `_wsga_cmd_name' `_wsga_ys_r1' `_wsga_cmd_rhs'
-        if !_rc {
+        capture {
+          qui `_wsga_cmd_name' `_wsga_ys_r1' `_wsga_cmd_rhs'
           scalar _wcbr_draw_g1 = _b[1.`svar'#1.`cvar']
+        }
+        if !_rc {
           if abs(_wcbr_draw_g1) >= abs(b[1,2]) ///
             scalar _wcbr_count_g1 = _wcbr_count_g1 + 1
           scalar _wcbr_B_g1 = _wcbr_B_g1 + 1
@@ -919,9 +945,11 @@ program define _wsga_rdd_myboo, eclass
 
         qui gen double `_wsga_ys_rdiff' = ///
           `_wsga_xb_rdiff' + `_wsga_sign' * `_wsga_resid_rdiff' if `esample'
-        capture qui `_wsga_cmd_name' `_wsga_ys_rdiff' `_wsga_cmd_rhs'
-        if !_rc {
+        capture {
+          qui `_wsga_cmd_name' `_wsga_ys_rdiff' `_wsga_cmd_rhs'
           scalar _wcbr_draw_diff = _b[1.`svar'#1.`cvar'] - _b[0.`svar'#1.`cvar']
+        }
+        if !_rc {
           scalar _orig_diff = b[1,2] - b[1,1]
           if abs(_wcbr_draw_diff) >= abs(_orig_diff) ///
             scalar _wcbr_count_diff = _wcbr_count_diff + 1
@@ -996,32 +1024,77 @@ program define _wsga_rdd_myboo, eclass
       qui replace `kernelipsw' = `ipsweight' * `kwt'
     }
 
-      // Refit the SAVED outcome command, not e(cmdline): the propensity-score
-      // logit above clobbers e(cmdline), so `e(cmdline)' would re-run the logit
-      // (which has no treatment coefficient) and _b[] would fail with r(111) on
-      // every IPW replicate (#43).
-      qui `_saved_cmdline'
+      // Refit the SAVED outcome command, not e(cmdline): the PS logit above
+      // clobbers e(cmdline), so `e(cmdline)' would re-run the logit and the
+      // treatment coefficient would be absent (#43).
+      capture qui `_saved_cmdline'
+      if _rc local _rep_ok = 0
+      // Drop the replicate if resampling emptied a subgroup x cutoff cell: the
+      // treatment coef is then omitted and would silently enter as 0 (#43).
+      if `_rep_ok' {
+        forvalues g = 0/1 {
+          qui count if e(sample) & `svar' == `g' & _cutoff == 0
+          local _n_below = r(N)
+          qui count if e(sample) & `svar' == `g' & _cutoff == 1
+          local _n_above = r(N)
+          if `_n_below' == 0 | `_n_above' == 0 local _rep_ok = 0
+        }
+      }
     }
-    tempname this_run
-    // Non-IV or bootstrap-both-stages
-    if IndIV[1,1]==0 | fixed[1,1]==0 {
-      local b_g0_i = _b[0.`svar'#1.`cvar']
-      local b_g1_i = _b[1.`svar'#1.`cvar']
-      mat `this_run' = (`b_g0_i', `b_g1_i', `b_g1_i' - `b_g0_i')
+    // Coefficient extraction: guarded so an omitted coef in this replicate
+    // drops the rep rather than aborting the whole run (#43).
+    if `_rep_ok' {
+      tempname this_run
+      if IndIV[1,1]==0 | fixed[1,1]==0 {
+        capture {
+          local b_g0_i = _b[0.`svar'#1.`cvar']
+          local b_g1_i = _b[1.`svar'#1.`cvar']
+          mat `this_run' = (`b_g0_i', `b_g1_i', `b_g1_i' - `b_g0_i')
+        }
+        if _rc local _rep_ok = 0
+      }
+      if `_rep_ok' & (IndIV[1,1]==1 & fixed[1,1]==1) {
+        capture {
+          local CoeffIVg0_`i' = _b[0.`svar'#1._cutoff]/FS[1,1]
+          local CoeffIVg1_`i' = _b[1.`svar'#1._cutoff]/FS[1,2]
+          mat `this_run' = (`CoeffIVg0_`i'', `CoeffIVg1_`i'', ///
+            `CoeffIVg1_`i'' - `CoeffIVg0_`i'')
+        }
+        if _rc local _rep_ok = 0
+      }
     }
-    // IV with fixed first stage: bootstrap reduced form, divide by saved FS coefs
-    if IndIV[1,1]==1 & fixed[1,1]==1 {
-      local CoeffIVg0_`i' = _b[0.`svar'#1._cutoff]/FS[1,1]
-      local CoeffIVg1_`i' = _b[1.`svar'#1._cutoff]/FS[1,2]
-      mat `this_run' = (`CoeffIVg0_`i'', `CoeffIVg1_`i'', ///
-        `CoeffIVg1_`i'' - `CoeffIVg0_`i'')
+    if `_rep_ok' {
+      mat cumulative = nullmat(cumulative) \ `this_run'
+      local ++B_ok
     }
-    mat cumulative = nullmat(cumulative) \ `this_run'
     restore
-    _dots `i' 0
+    if `_rep_ok' _dots `i' 0
+    else         _dots `i' 1
   }
 
   di _newline
+  // Abort if every replicate failed
+  if `B_ok' == 0 {
+    di as error "wsga rdd: all `B' bootstrap replicates failed; no inference is possible."
+    di as error "The estimation sample is likely too sparse for bootstrap inference."
+    di as error "Consider widening the bandwidth, dropping block(), or using noipsw."
+    exit 1
+  }
+  // Warn when the drop rate is non-trivial
+  if `B_ok' < `B' {
+    local _n_dropped = `B' - `B_ok'
+    local _pct_dropped = round(100 * `_n_dropped' / `B')
+    if `_pct_dropped' >= 10 {
+      di as error "Warning: `_n_dropped' of `B' bootstrap replicates were dropped (`_pct_dropped'% failure rate)."
+      di as error "Bootstrap SEs and CIs may be unreliable. Consider:"
+      di as error "  - dropping or coarsening the block() stratification variable"
+      di as error "  - widening the bandwidth"
+      di as error "  - using noipsw to disable propensity score weighting"
+    }
+    else {
+      di as text "Note: `_n_dropped' of `B' bootstrap replicates were dropped; B_ok = `B_ok'."
+    }
+  }
   // Compute 2x2 VCV from first two columns (g0, g1)
   cap mat drop V
   mata: cumulative = st_matrix("cumulative")
@@ -1042,7 +1115,7 @@ program define _wsga_rdd_myboo, eclass
     ereturn scalar `scalar' = ``scalar''
   }
   ereturn scalar N_reps = `B'
-  ereturn scalar B_ok   = `B'
+  ereturn scalar B_ok   = `B_ok'
   ereturn scalar level = 95
   if "`cluster'" != "" {
     ereturn scalar N_clust = `_N_clust'
@@ -1059,23 +1132,24 @@ program define _wsga_rdd_myboo, eclass
   }
   else {
     // WCB-U and pairs: recentered formula on unrestricted draws
+    // Use B_ok (surviving reps) for iteration and denominator (#43).
     cap scalar drop bscoef
     forvalues g = 0/1 {
       local count = 0
-      forvalues i = 1/`B' {
+      forvalues i = 1/`B_ok' {
         scalar bscoef = cumulative[`i',`=`g'+1']
         if abs(bscoef - b[1,`=`g'+1']) >= abs(b[1,`=`g'+1']) local count = `count'+1
       }
-      scalar pval`g' = (1+`count') / (`B' + 1)
+      scalar pval`g' = (1+`count') / (`B_ok' + 1)
       ereturn scalar p_g`g' = pval`g'
     }
     scalar orig_diff = b[1,2] - b[1,1]
     local count_diff = 0
-    forvalues i = 1/`B' {
+    forvalues i = 1/`B_ok' {
       scalar bscoef = cumulative[`i',3]
       if abs(bscoef - orig_diff) >= abs(orig_diff) local count_diff = `count_diff' + 1
     }
-    scalar pval_diff = (1 + `count_diff') / (`B' + 1)
+    scalar pval_diff = (1 + `count_diff') / (`B_ok' + 1)
     ereturn scalar p_diff = pval_diff
   }
   // Empirical confidence intervals

--- a/stata/wsga.pkg
+++ b/stata/wsga.pkg
@@ -1,4 +1,4 @@
-v 1.3.3
+v 1.3.4
 d 'WSGA': Weighted subgroup analysis
 d
 d  wsga conducts weighted subgroup analysis for research designs that

--- a/stata/wsga.sthlp
+++ b/stata/wsga.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.3 2026-05-28}{...}
+{* *! version 1.3.4 2026-05-28}{...}
 {title:Title}
 
 {pstd}

--- a/stata/wsga_did.sthlp
+++ b/stata/wsga_did.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.3 2026-05-28}{...}
+{* *! version 1.3.4 2026-05-28}{...}
 {viewerjumpto "Stored results" "wsga_did##results"}{...}
 {title:Title}
 

--- a/stata/wsga_rdd.sthlp
+++ b/stata/wsga_rdd.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.3.3 2026-05-28}{...}
+{* *! version 1.3.4 2026-05-28}{...}
 {viewerjumpto "Stored results" "wsga_rdd##results"}{...}
 {title:Title}
 

--- a/tests/testthat/test-estimation.R
+++ b/tests/testthat/test-estimation.R
@@ -60,6 +60,17 @@ test_that("triangular kernel runs", {
   expect_s3_class(fit, "wsga")
 })
 
+test_that("unidentified subgroup (no support on one side) errors clearly (#43)", {
+  d <- rddsga_synth
+  # Subgroup lives entirely on one side of the cutoff: G==0 only above, G==1 only below.
+  d$sg1 <- as.integer(d$x < 0)
+  expect_error(
+    wsga_rdd(y ~ 1 | sg1, data = d, running = ~ x, bwidth = 0.5,
+             noipsw = TRUE, bootstrap = FALSE),
+    "no observations on one side of the cutoff"
+  )
+})
+
 test_that("fuzzy IV model runs", {
   fit <- wsga_rdd(y ~ 1 | sgroup, data = rddsga_synth,
                   running = ~ x, bwidth = 0.5,


### PR DESCRIPTION
## Summary

Closes #45. Follow-up hardening to #43/#44. The crash itself was fixed in #44 (`_saved_cmdline`); this PR hardens the surrounding bootstrap behavior and adds a clear fail-fast in both languages. No new public arguments/options — patch release `1.3.4`.

## Changes

**Stata (`_wsga_rdd_myboo`):**
- `capture` the per-replicate refit + coefficient extraction; **drop degenerate replicates** instead of aborting (honors the "failed reps dropped with a warning" contract the R side already follows).
- **Cell-count guard:** a resample that empties a subgroup×cutoff cell yields an omitted treatment coefficient that would otherwise enter the bootstrap distribution as a spurious `0`. Such reps are dropped, not counted. (Demonstrated: a thin-cell design drops ~15/100 reps.)
- **Accurate `B_ok`:** track the true surviving-replicate count and `ereturn` it (was hardcoded to `B`); use `B_ok` in the p-value / percentile-CI denominators.
- **Warnings:** informational note on any drops; prominent warning above a 10% drop rate; clean abort if all replicates fail.
- **Fail-fast:** abort with a clear message when a subgroup has no observations on one side of the cutoff in the estimation sample (was a cryptic mid-bootstrap crash). Check is on cutoff side, valid for sharp and fuzzy.

**R (`wsga.R`):** add the matching fail-fast. Previously a structurally unidentified subgroup errored with a cryptic `subscript out of bounds` in `extract_estimates`.

## Tests

- `stata/tests/smoke_rdd_ipw_boot.do` expanded: healthy IPW (`B_ok == N_reps`), `noipsw`, thin-cell **partial drop** (`1 <= B_ok < N_reps`), **fail-fast** (`r(111)`), and IPW fuzzy `ivregress`/`firststage` — all pass (6/6).
- R `test-estimation.R`: new fail-fast case. Full `testthat` 167 pass, 0 fail.
- Full Stata smoke suite green.

## Notes

`wsga did` already wraps replicates in `capture` with `B_ok` tracking — unchanged. The duplicate-collinear-terms cleanup is tracked separately in #46.
