### PR TITLE
fix(landing): pin mobile hero stage (inset:auto was clobbering top:0)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -52,7 +52,7 @@
   #hero{width:100%;height:100%;display:block;}
   .mprog{display:none;}                              /* progress bar: mobile-only */
   @media(max-width:760px){
-    .stage{position:sticky;top:0;inset:auto;height:46vh;z-index:2;
+    .stage{position:sticky;inset:auto;top:0;height:46vh;z-index:2;
            background:var(--paper);border-bottom:1px solid var(--panel-border);}
     .mprog{display:block;position:absolute;left:0;right:0;bottom:0;height:3px;background:var(--panel-border);}
     .mprog i{display:block;height:100%;width:0;background:var(--red);}


### PR DESCRIPTION
## Problem

On mobile, the hero canvas disappeared off the top of the viewport as soon as scrolling began — it never pinned. Originally suspected to be an iOS-Safari `<canvas>`-in-`sticky` compositing bug (handoff from #50), but it reproduces in **Chrome device emulation too**, so it is browser-independent.

## Root cause

The mobile `.stage` rule declared offsets in the wrong order:

```css
.stage{position:sticky; top:0; inset:auto; ...}
```

`inset` is shorthand for `top/right/bottom/left`, so `inset:auto` (added to undo the desktop `inset:0`) **reset `top` back to `auto`**. A sticky element with `top:auto` has no anchor edge and behaves like static — it scrolls away with the page.

## Fix

One line — reorder so the offset reset comes before `top`:

```css
.stage{position:sticky; inset:auto; top:0; ...}
```

## Verification

Measured via a Chrome DevTools-Protocol harness driving real scrolling at a 393x852 / DPR-3 mobile viewport:

| | before | after |
|---|---|---|
| computed `top` | `auto` | `0px` |
| stage `rect.top` while scrolling | 216 → 116 → -83 → -383 (scrolls off) | 222 → 122 → 0 → 0 (pins) |

Stable across 3 runs. **Caveat:** verified in headless Chrome emulation, not yet on a physical iPhone. The fix is deterministic per the CSS spec, so it will behave the same on iOS Safari, but on-device confirmation is still recommended before closing out the mobile work.

Docs-only change; no version bump required.